### PR TITLE
bench: extend ca-GrQc crossover through 50% updates

### DIFF
--- a/.github/workflows/public-small-dataset.yml
+++ b/.github/workflows/public-small-dataset.yml
@@ -113,7 +113,7 @@ jobs:
 
           path = Path('build/public-small/update-fraction-ca-GrQc.csv')
           rows = list(csv.DictReader(path.open()))
-          assert len(rows) == 70
+          assert len(rows) == 90
           assert {int(r['vertices']) for r in rows} == {5242}
           assert {int(r['base_edges']) for r in rows} == {14484}
           assert all(r['correct'] == '1' for r in rows)
@@ -124,7 +124,7 @@ jobs:
           grouped = defaultdict(list)
           for row in rows:
             grouped[row['update_fraction']].append(float(row['speedup']))
-          assert len(grouped) == 7
+          assert len(grouped) == 9
           assert all(len(values) == 10 for values in grouped.values())
 
           summary = {
@@ -192,7 +192,7 @@ jobs:
             --result build/public-small/update-fraction-ca-GrQc.csv \
             --result build/public-small/update-fraction-summary.json \
             --result build/public-small/competitor-summary.json \
-            --notes 'Real public ca-GrQc dataset on GitHub-hosted CI; incremental crossover and correctness evidence; research_claim=false; not publication-grade performance.' \
+            --notes 'Real public ca-GrQc dataset on GitHub-hosted CI; extended incremental crossover and correctness evidence through 50% updates; research_claim=false; not publication-grade performance.' \
             --output build/public-small/result-bundle.json
           python tools/validate_result_bundle.py build/public-small/result-bundle.json
 

--- a/benchmarks/public_update_fraction_campaign.cpp
+++ b/benchmarks/public_update_fraction_campaign.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -68,6 +69,11 @@ velographx::DynamicGraph make_graph(std::size_t vertex_count, const std::vector<
   return graph;
 }
 
+std::uint64_t edge_key(velographx::VertexId u, velographx::VertexId v) {
+  if (u > v) std::swap(u, v);
+  return (static_cast<std::uint64_t>(u) << 32U) | static_cast<std::uint64_t>(v);
+}
+
 velographx::UpdateBatch make_updates(
     const velographx::DynamicGraph& graph,
     std::size_t requested,
@@ -75,6 +81,9 @@ velographx::UpdateBatch make_updates(
   velographx::UpdateBatch batch;
   batch.updates.reserve(requested);
   if (graph.vertex_count() < 2 || requested == 0) return batch;
+
+  std::unordered_set<std::uint64_t> selected;
+  selected.reserve(requested * 2 + 1);
 
   const auto n = static_cast<std::uint64_t>(graph.vertex_count());
   std::uint64_t state = seed | 1ULL;
@@ -87,14 +96,8 @@ velographx::UpdateBatch make_updates(
     const auto v = static_cast<velographx::VertexId>((state >> 17) % n);
     if (u == v || graph.has_edge(u, v)) continue;
 
-    bool duplicate = false;
-    for (const auto& op : batch.updates) {
-      if ((op.src == u && op.dst == v) || (op.src == v && op.dst == u)) {
-        duplicate = true;
-        break;
-      }
-    }
-    if (!duplicate) batch.add(u, v);
+    const auto key = edge_key(u, v);
+    if (selected.insert(key).second) batch.add(u, v);
   }
 
   if (batch.updates.size() != requested) {
@@ -125,8 +128,8 @@ int main(int argc, char** argv) {
     return 2;
   }
 
-  constexpr std::array<double, 7> fractions = {
-      0.000001, 0.00001, 0.0001, 0.001, 0.01, 0.05, 0.10};
+  constexpr std::array<double, 9> fractions = {
+      0.000001, 0.00001, 0.0001, 0.001, 0.01, 0.05, 0.10, 0.20, 0.50};
   using clock = std::chrono::steady_clock;
 
   std::cout << "dataset,algorithm,vertices,base_edges,update_fraction,requested_edges,changed_edges,repeat,incremental_ns,full_recompute_ns,speedup,incremental_triangles,recomputed_triangles,correct\n";


### PR DESCRIPTION
## Summary

Extends the real ca-GrQc incremental triangle crossover campaign beyond the existing 10% update point to locate the actual crossover region on the currently available GitHub-hosted CPU runner.

### Changes
- extends update fractions from 7 points to 9 points by adding 20% and 50%
- keeps 10 repetitions per fraction (90 measured runs)
- preserves the hard correctness gate against full recomputation
- replaces quadratic duplicate detection in update generation with a canonical-edge hash set so larger batches remain practical
- updates the public evidence workflow and result-bundle notes

## Motivation

The merged public ca-GrQc artifact showed median speedups of ~60x at 1%, ~13.3x at 5%, and ~7.1x at 10%, so the crossover had not yet been reached. This PR extends the same controlled experiment rather than adding unrelated features.

`research_claim=false` remains unchanged; this is engineering evidence on hosted CI, not publication-grade performance.