### PR TITLE
bench: extend ca-GrQc crossover through 200% updates

### DIFF
--- a/.github/workflows/public-small-dataset.yml
+++ b/.github/workflows/public-small-dataset.yml
@@ -113,7 +113,7 @@ jobs:
 
           path = Path('build/public-small/update-fraction-ca-GrQc.csv')
           rows = list(csv.DictReader(path.open()))
-          assert len(rows) == 90
+          assert len(rows) == 130
           assert {int(r['vertices']) for r in rows} == {5242}
           assert {int(r['base_edges']) for r in rows} == {14484}
           assert all(r['correct'] == '1' for r in rows)
@@ -124,8 +124,9 @@ jobs:
           grouped = defaultdict(list)
           for row in rows:
             grouped[row['update_fraction']].append(float(row['speedup']))
-          assert len(grouped) == 9
+          assert len(grouped) == 13
           assert all(len(values) == 10 for values in grouped.values())
+          assert {'0.75', '1', '1.5', '2'} <= set(grouped)
 
           summary = {
               'schema_version': 1,
@@ -192,7 +193,7 @@ jobs:
             --result build/public-small/update-fraction-ca-GrQc.csv \
             --result build/public-small/update-fraction-summary.json \
             --result build/public-small/competitor-summary.json \
-            --notes 'Real public ca-GrQc dataset on GitHub-hosted CI; extended incremental crossover and correctness evidence through 50% updates; research_claim=false; not publication-grade performance.' \
+            --notes 'Real public ca-GrQc dataset on GitHub-hosted CI; extended incremental crossover and correctness evidence through 200% updates; research_claim=false; not publication-grade performance.' \
             --output build/public-small/result-bundle.json
           python tools/validate_result_bundle.py build/public-small/result-bundle.json
 

--- a/benchmarks/public_update_fraction_campaign.cpp
+++ b/benchmarks/public_update_fraction_campaign.cpp
@@ -128,8 +128,9 @@ int main(int argc, char** argv) {
     return 2;
   }
 
-  constexpr std::array<double, 9> fractions = {
-      0.000001, 0.00001, 0.0001, 0.001, 0.01, 0.05, 0.10, 0.20, 0.50};
+  constexpr std::array<double, 13> fractions = {
+      0.000001, 0.00001, 0.0001, 0.001, 0.01, 0.05, 0.10, 0.20, 0.50,
+      0.75, 1.00, 1.50, 2.00};
   using clock = std::chrono::steady_clock;
 
   std::cout << "dataset,algorithm,vertices,base_edges,update_fraction,requested_edges,changed_edges,repeat,incremental_ns,full_recompute_ns,speedup,incremental_triangles,recomputed_triangles,correct\n";


### PR DESCRIPTION
## Summary
- extend the public ca-GrQc incremental triangle crossover sweep with 75%, 100%, 150%, and 200% update fractions
- increase the campaign from 90 to 130 measurements (13 fractions × 10 repeats)
- preserve exact incremental-vs-full-recompute correctness validation for every measurement
- update the CI artifact contract and provenance notes to reflect the expanded sweep

## Why
The previous hosted-CI evidence still showed ~2x median speedup at 50% updates, so the actual crossover point had not been reached. This PR extends the sweep to determine whether/where incremental maintenance stops outperforming full recomputation.

## Evidence policy
`research_claim` remains false. These are reproducible GitHub-hosted engineering measurements, not publication-grade performance claims.