### PR TITLE
bench: pin web-Google metadata and crossover plan

### DIFF
--- a/.github/workflows/public-dataset-plan.yml
+++ b/.github/workflows/public-dataset-plan.yml
@@ -23,7 +23,7 @@ jobs:
           assert report['valid_plan'] is True
           assert report['execution_ready'] is False
           assert report['slot_count'] == 3
-          assert report['incomplete_slots'] == ['100m-plus-public', 'medium-public']
+          assert report['incomplete_slots'] == ['100m-plus-public']
           PY
       - name: Fail closed when execution readiness is required
         run: |

--- a/datasets/manifest.public-medium.json
+++ b/datasets/manifest.public-medium.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "datasets": [
+    {
+      "name": "web-Google",
+      "url": "https://raw.githubusercontent.com/ease-lab/dbg/3737683c0a0bcff6469a4691c16f51425a6bbfd3/datasets/web-Google.txt",
+      "sha256": "8c0f453f1eb1e24ad145e36e542b129083237e96e585abae768927bdb70167d1",
+      "format": "edge-list-text",
+      "directed": true,
+      "weighted": false,
+      "vertex_count": 875713,
+      "edge_count": 5105039,
+      "research_claim": false
+    }
+  ]
+}

--- a/datasets/public-research-plan.json
+++ b/datasets/public-research-plan.json
@@ -35,15 +35,21 @@
     {
       "id": "medium-public",
       "role": "crossover-and-scaling",
-      "canonical_source": null,
-      "license_or_terms": null,
-      "download_url": null,
-      "sha256": null,
-      "format": null,
-      "directed": null,
-      "vertex_count": null,
-      "edge_count": null,
-      "ready": false
+      "name": "web-Google",
+      "canonical_source": "https://snap.stanford.edu/data/web-Google.html",
+      "license_or_terms": "Publicly downloadable through the Stanford SNAP dataset collection; cite the SNAP/web-Google source. No separate dataset-specific license is asserted by VeloGraphX.",
+      "download_url": "https://raw.githubusercontent.com/ease-lab/dbg/3737683c0a0bcff6469a4691c16f51425a6bbfd3/datasets/web-Google.txt",
+      "source_revision": "3737683c0a0bcff6469a4691c16f51425a6bbfd3",
+      "sha256": "8c0f453f1eb1e24ad145e36e542b129083237e96e585abae768927bdb70167d1",
+      "format": "edge-list-text",
+      "directed": true,
+      "vertex_count": 875713,
+      "edge_count": 5105039,
+      "raw_edge_rows": 5105039,
+      "self_loop_rows": 0,
+      "duplicate_or_reverse_rows": 0,
+      "ready": true,
+      "research_claim": false
     },
     {
       "id": "100m-plus-public",
@@ -59,5 +65,5 @@
       "ready": false
     }
   ],
-  "notes": "The small-public ca-GrQc slot was populated only after the Public Dataset Verification workflow downloaded an immutable revision and measured its SHA-256/counts. Medium and 100M+ slots remain intentionally unresolved."
+  "notes": "The ca-GrQc and web-Google slots were populated only after the Public Dataset Verification workflow downloaded immutable revisions and measured their SHA-256/counts. The 100M+ slot remains intentionally unresolved."
 }

--- a/datasets/web-google-crossover-plan.json
+++ b/datasets/web-google-crossover-plan.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "artifact_type": "velographx-crossover-plan",
+  "dataset": "web-Google",
+  "research_claim": false,
+  "purpose": "Practical hosted-runner crossover sweep for the verified web-Google dataset.",
+  "update_fractions": [0.001, 0.005, 0.01, 0.02, 0.05],
+  "repetitions": 5,
+  "correctness": "incremental result must equal full recomputation for every measurement",
+  "report": ["median", "p95", "per-run timings", "correctness"],
+  "notes": "Start conservatively because web-Google has 5,105,039 directed edges. Larger fractions may be added only after runtime and memory are observed on hosted CI."
+}


### PR DESCRIPTION
## Summary
- pin the verified web-Google SHA-256, counts, directedness, and immutable source in the public research plan
- add `datasets/manifest.public-medium.json`
- define an initial hosted-runner crossover sweep at 0.1%, 0.5%, 1%, 2%, and 5% updates with 5 repetitions
- preserve `research_claim=false`

## Why
PR #6 verified web-Google successfully. This follow-up converts that verification artifact into pinned repository metadata and a conservative execution plan before wiring it into benchmark CI.

## Notes
The sweep is intentionally conservative because web-Google has 5,105,039 directed edges; larger fractions should be added only after observing hosted-runner runtime and memory.

Part of #4.