### PR TITLE
bench: add multi-dataset incremental crossover campaign

### DIFF
--- a/.github/workflows/multi-dataset-crossover.yml
+++ b/.github/workflows/multi-dataset-crossover.yml
@@ -1,0 +1,159 @@
+name: Multi-Dataset Incremental Crossover
+
+on:
+  push:
+    paths:
+      - '.github/workflows/multi-dataset-crossover.yml'
+      - 'datasets/multi-dataset-crossover.json'
+      - 'tools/prepare_pinned_public_dataset.py'
+      - 'tools/normalize_edge_list.py'
+      - 'tools/summarize_update_crossover.py'
+      - 'benchmarks/public_update_fraction_campaign.cpp'
+      - 'tools/build_result_artifact.py'
+      - 'tools/validate_result_bundle.py'
+      - 'CMakeLists.txt'
+  pull_request:
+    paths:
+      - '.github/workflows/multi-dataset-crossover.yml'
+      - 'datasets/multi-dataset-crossover.json'
+      - 'tools/prepare_pinned_public_dataset.py'
+      - 'tools/normalize_edge_list.py'
+      - 'tools/summarize_update_crossover.py'
+      - 'benchmarks/public_update_fraction_campaign.cpp'
+      - 'tools/build_result_artifact.py'
+      - 'tools/validate_result_bundle.py'
+      - 'CMakeLists.txt'
+  workflow_dispatch:
+
+jobs:
+  crossover:
+    name: ${{ matrix.dataset }} crossover
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dataset: ca-HepTh
+            family: collaboration
+          - dataset: facebook-combined
+            family: social
+          - dataset: p2p-Gnutella08
+            family: peer-to-peer-network
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Acquire immutable public dataset
+        run: |
+          mkdir -p "build/multi/${{ matrix.dataset }}/source"
+          python tools/prepare_pinned_public_dataset.py \
+            --manifest datasets/multi-dataset-crossover.json \
+            --dataset '${{ matrix.dataset }}' \
+            --output-dir "build/multi/${{ matrix.dataset }}/source" \
+            > "build/multi/${{ matrix.dataset }}/dataset-prepared.json"
+
+      - name: Normalize to undirected simple graph
+        run: |
+          python tools/normalize_edge_list.py \
+            --input "build/multi/${{ matrix.dataset }}/source/${{ matrix.dataset }}.txt" \
+            --output "build/multi/${{ matrix.dataset }}/${{ matrix.dataset }}-normalized.txt" \
+            --report "build/multi/${{ matrix.dataset }}/normalization.json"
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          base = Path('build/multi/${{ matrix.dataset }}')
+          prepared = json.loads((base / 'dataset-prepared.json').read_text())
+          normalized = json.loads((base / 'normalization.json').read_text())
+          assert prepared['research_claim'] is False
+          assert normalized['research_claim'] is False
+          assert normalized['vertex_count'] > 1
+          assert normalized['edge_count'] > 0
+          assert normalized['source_sha256'] == prepared['prepared'][0]['sha256']
+          PY
+
+      - name: Configure and build benchmark
+        run: |
+          cmake -S . -B build/cmake \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DVELOGRAPHX_BUILD_TESTS=ON \
+            -DVELOGRAPHX_BUILD_BENCHMARKS=ON
+          cmake --build build/cmake -j 2
+          ctest --test-dir build/cmake --output-on-failure --timeout 60
+
+      - name: Capture environment and validate preflight
+        run: |
+          python tools/capture_benchmark_environment.py \
+            --label "github-hosted-${{ matrix.dataset }}-multi-crossover" \
+            --output "build/multi/${{ matrix.dataset }}/environment.json"
+          python tools/validate_benchmark_preflight.py \
+            --environment "build/multi/${{ matrix.dataset }}/environment.json" \
+            --dataset-report "build/multi/${{ matrix.dataset }}/dataset-prepared.json" \
+            > "build/multi/${{ matrix.dataset }}/preflight.json"
+
+      - name: Run repeated incremental crossover sweep
+        run: |
+          build/cmake/velographx_public_update_fraction_benchmark \
+            "build/multi/${{ matrix.dataset }}/${{ matrix.dataset }}-normalized.txt" \
+            5 \
+            '0.000001,0.00001,0.0001,0.001,0.01,0.05,0.10,0.20,0.50,0.75,1.00,1.50,2.00' \
+            > "build/multi/${{ matrix.dataset }}/update-fraction.csv"
+          python tools/summarize_update_crossover.py \
+            --input "build/multi/${{ matrix.dataset }}/update-fraction.csv" \
+            --dataset '${{ matrix.dataset }}' \
+            --family '${{ matrix.family }}' \
+            --output "build/multi/${{ matrix.dataset }}/update-fraction-summary.json"
+
+      - name: Validate measurement contract
+        run: |
+          python - <<'PY'
+          import csv, json
+          from pathlib import Path
+          base = Path('build/multi/${{ matrix.dataset }}')
+          rows = list(csv.DictReader((base / 'update-fraction.csv').open()))
+          summary = json.loads((base / 'update-fraction-summary.json').read_text())
+          assert len(rows) == 65
+          assert len(summary['fractions']) == 13
+          assert summary['repeats_per_fraction'] == 5
+          assert summary['all_incremental_results_match_full_recompute'] is True
+          assert all(row['correct'] == '1' for row in rows)
+          assert all(int(row['changed_edges']) == int(row['requested_edges']) for row in rows)
+          assert all(int(row['incremental_ns']) > 0 for row in rows)
+          assert all(int(row['full_recompute_ns']) > 0 for row in rows)
+          PY
+
+      - name: Build and validate provenance-rich result bundle
+        shell: bash
+        run: |
+          DATASET_SHA256=$(python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path('build/multi/${{ matrix.dataset }}/dataset-prepared.json').read_text())
+          print(report['prepared'][0]['sha256'])
+          PY
+          )
+          python tools/build_result_artifact.py \
+            --experiment "multi-dataset-${{ matrix.dataset }}-hosted-ci" \
+            --dataset '${{ matrix.dataset }}' \
+            --dataset-sha256 "$DATASET_SHA256" \
+            --preflight-json "build/multi/${{ matrix.dataset }}/preflight.json" \
+            --hardware-json "build/multi/${{ matrix.dataset }}/environment.json" \
+            --software-json "build/multi/${{ matrix.dataset }}/environment.json" \
+            --result "build/multi/${{ matrix.dataset }}/dataset-prepared.json" \
+            --result "build/multi/${{ matrix.dataset }}/normalization.json" \
+            --result "build/multi/${{ matrix.dataset }}/update-fraction.csv" \
+            --result "build/multi/${{ matrix.dataset }}/update-fraction-summary.json" \
+            --notes 'GitHub-hosted multi-dataset incremental triangle crossover engineering evidence; exact correctness checked for every sample; research_claim=false; not publication-grade performance.' \
+            --output "build/multi/${{ matrix.dataset }}/result-bundle.json"
+          python tools/validate_result_bundle.py "build/multi/${{ matrix.dataset }}/result-bundle.json"
+
+      - name: Upload machine-readable evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: velographx-multi-crossover-${{ matrix.dataset }}
+          path: build/multi/${{ matrix.dataset }}/
+          retention-days: 30

--- a/datasets/multi-dataset-crossover.json
+++ b/datasets/multi-dataset-crossover.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "artifact_type": "velographx-multi-dataset-crossover-manifest",
+  "research_claim": false,
+  "datasets": [
+    {
+      "name": "ca-HepTh",
+      "family": "collaboration",
+      "role": "larger-collaboration",
+      "canonical_source": "https://snap.stanford.edu/data/ca-HepTh.html",
+      "license_or_terms": "Publicly downloadable through the Stanford SNAP dataset collection; cite the SNAP/ca-HepTh source. No separate dataset-specific license is asserted by VeloGraphX.",
+      "url": "https://raw.githubusercontent.com/SaraSherinThomas/Triangle-Counting-in-Data-Streams/16e8af9fddcd661c632cd69c07464de939512c1b/CA_hep.txt",
+      "source_revision": "16e8af9fddcd661c632cd69c07464de939512c1b",
+      "git_blob_sha1": "9a54c32c1c12aee65674ad05f2bb966fb037445e",
+      "format": "edge-list-text",
+      "directed": false,
+      "weighted": false,
+      "research_claim": false
+    },
+    {
+      "name": "facebook-combined",
+      "family": "social",
+      "role": "denser-social",
+      "canonical_source": "https://snap.stanford.edu/data/ego-Facebook.html",
+      "license_or_terms": "Publicly downloadable through the Stanford SNAP dataset collection; cite the SNAP ego-Facebook source. No separate dataset-specific license is asserted by VeloGraphX.",
+      "url": "https://raw.githubusercontent.com/SaraSherinThomas/Triangle-Counting-in-Data-Streams/16e8af9fddcd661c632cd69c07464de939512c1b/facebook_combined.txt",
+      "source_revision": "16e8af9fddcd661c632cd69c07464de939512c1b",
+      "git_blob_sha1": "9a65fc5e22d64d298a3823d1569ae6740800c52f",
+      "format": "edge-list-text",
+      "directed": false,
+      "weighted": false,
+      "research_claim": false
+    },
+    {
+      "name": "p2p-Gnutella08",
+      "family": "peer-to-peer-network",
+      "role": "network-structure",
+      "canonical_source": "https://snap.stanford.edu/data/p2p-Gnutella08.html",
+      "license_or_terms": "Publicly downloadable through the Stanford SNAP dataset collection; cite the SNAP p2p-Gnutella08 source. No separate dataset-specific license is asserted by VeloGraphX.",
+      "url": "https://raw.githubusercontent.com/Zhuoang2/CS225-UIUC-Gnutella-P2P-Network_Visualization/72afb1909a643b867c1959f7cf0c6e1f9b74715a/Final_Project/tests/p2p-Gnutella08.txt",
+      "source_revision": "72afb1909a643b867c1959f7cf0c6e1f9b74715a",
+      "git_blob_sha1": "8f884f315aa0452e0ef7a87a61849f09e2bee014",
+      "format": "edge-list-text",
+      "directed": false,
+      "weighted": false,
+      "research_claim": false
+    }
+  ]
+}

--- a/docs/multi-dataset-crossover.md
+++ b/docs/multi-dataset-crossover.md
@@ -1,0 +1,48 @@
+# Multi-dataset incremental crossover campaign
+
+This campaign extends the hosted-CI incremental triangle-maintenance evidence beyond `ca-GrQc` to structurally different public graphs. It is **engineering evidence only** and remains explicitly `research_claim=false`; it is not a publication-grade performance claim.
+
+## Dataset families
+
+The campaign uses three additional public graph structures:
+
+| Dataset | Family / role | Source identity |
+| --- | --- | --- |
+| `ca-HepTh` | larger collaboration graph | immutable Git revision + verified Git blob |
+| `facebook-combined` | denser social graph | immutable Git revision + verified Git blob |
+| `p2p-Gnutella08` | peer-to-peer network graph | immutable Git revision + verified Git blob |
+
+Canonical dataset provenance is recorded in `datasets/multi-dataset-crossover.json`. The benchmark downloads only immutable revision URLs, verifies the expected Git blob identity before use, and records a SHA-256 digest of the acquired bytes in the result artifact.
+
+## Methodology
+
+Each source edge list is deterministically normalized to a simple undirected graph because the current incremental triangle benchmark evaluates undirected triangle maintenance. Self-loops are removed, reverse/duplicate edges are deduplicated, and vertex IDs are remapped contiguously.
+
+For each normalized graph, `velographx_public_update_fraction_benchmark` runs five independent repetitions at each configured update fraction:
+
+`1e-6, 1e-5, 1e-4, 1e-3, 0.01, 0.05, 0.10, 0.20, 0.50, 0.75, 1.00, 1.50, 2.00`
+
+Each repetition starts from the same base graph and generates a deterministic batch of previously absent edges. The campaign records both the requested number of updates and the number actually changed. The run fails if those values differ.
+
+For every measurement, the incremental triangle result is compared exactly with a full recomputation. A single disagreement fails the benchmark and therefore fails CI.
+
+## Reported statistics
+
+`tools/summarize_update_crossover.py` emits a machine-readable JSON summary containing, for each update fraction:
+
+- number of samples;
+- requested and actual changed-edge counts;
+- median and p95 incremental time;
+- median and p95 full-recompute time;
+- median and p95 speedup;
+- correctness rate.
+
+The summary also records graph vertex/base-edge counts and the first tested fraction whose median speedup is less than or equal to `1.0`. If none is observed, the result explicitly states that no crossover was reached within the configured sweep.
+
+## CI and provenance
+
+`.github/workflows/multi-dataset-crossover.yml` captures the GitHub-hosted runner environment, validates benchmark preflight metadata, runs the normal project test suite before measurement, validates all measurement contracts, builds a provenance-rich result bundle, and uploads the complete per-dataset artifact directory.
+
+Hosted-runner timings can be useful for correctness, crossover-shape exploration, regression detection and campaign plumbing. They must not be interpreted as evidence of superiority over other graph engines or as dedicated-hardware scalability results.
+
+A publication-grade follow-up should rerun the same artifact contract on controlled hardware with pinned compiler/runtime settings, dedicated CPU placement, larger public graphs, native competitors and enough repetitions for stable uncertainty estimates.

--- a/tools/prepare_pinned_public_dataset.py
+++ b/tools/prepare_pinned_public_dataset.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import pathlib
+import urllib.request
+
+
+def git_blob_sha1(data: bytes) -> str:
+    payload = f"blob {len(data)}\0".encode("ascii") + data
+    return hashlib.sha1(payload).hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Acquire one immutable public dataset and verify its Git blob identity.")
+    parser.add_argument("--manifest", type=pathlib.Path, required=True)
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--output-dir", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    if manifest.get("schema_version") != 1:
+        raise ValueError("unsupported manifest schema_version")
+    entries = {entry["name"]: entry for entry in manifest.get("datasets", [])}
+    if args.dataset not in entries:
+        raise ValueError(f"unknown dataset: {args.dataset}")
+    entry = entries[args.dataset]
+
+    if entry.get("research_claim") is not False or manifest.get("research_claim") is not False:
+        raise ValueError("hosted-CI public datasets must remain research_claim=false")
+    revision = entry.get("source_revision", "")
+    expected_blob = entry.get("git_blob_sha1", "").lower()
+    url = entry.get("url", "")
+    if len(revision) != 40 or any(c not in "0123456789abcdef" for c in revision.lower()):
+        raise ValueError("source_revision must be a full 40-character Git commit SHA")
+    if len(expected_blob) != 40 or any(c not in "0123456789abcdef" for c in expected_blob):
+        raise ValueError("git_blob_sha1 must be a 40-character lowercase hex digest")
+    if revision not in url:
+        raise ValueError("dataset URL must contain the immutable source_revision")
+
+    with urllib.request.urlopen(url) as response:
+        data = response.read()
+    actual_blob = git_blob_sha1(data)
+    if actual_blob != expected_blob:
+        raise ValueError(f"Git blob mismatch: expected {expected_blob}, got {actual_blob}")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    target = args.output_dir / f"{args.dataset}.txt"
+    target.write_bytes(data)
+    sha256 = hashlib.sha256(data).hexdigest()
+
+    report = {
+        "schema_version": 1,
+        "artifact_type": "velographx-pinned-public-dataset",
+        "research_claim": False,
+        "prepared": [{
+            "name": entry["name"],
+            "family": entry["family"],
+            "role": entry["role"],
+            "path": str(target),
+            "canonical_source": entry["canonical_source"],
+            "source_revision": revision,
+            "git_blob_sha1": actual_blob,
+            "sha256": sha256,
+            "format": entry.get("format"),
+            "directed": entry.get("directed"),
+            "weighted": entry.get("weighted"),
+        }],
+    }
+    print(json.dumps(report, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/summarize_update_crossover.py
+++ b/tools/summarize_update_crossover.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import json
+import math
+import pathlib
+import statistics
+from collections import defaultdict
+
+
+def p95(values):
+    ordered = sorted(values)
+    if not ordered:
+        raise ValueError("cannot compute p95 of empty input")
+    return ordered[max(0, math.ceil(0.95 * len(ordered)) - 1)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize VeloGraphX public update-fraction benchmark output.")
+    parser.add_argument("--input", type=pathlib.Path, required=True)
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--family", required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+
+    rows = list(csv.DictReader(args.input.open(newline="", encoding="utf-8")))
+    if not rows:
+        raise ValueError("benchmark CSV contains no rows")
+    if any(row["correct"] != "1" for row in rows):
+        raise ValueError("incremental result disagrees with full recomputation")
+    if any(int(row["changed_edges"]) != int(row["requested_edges"]) for row in rows):
+        raise ValueError("requested and changed edge counts differ")
+
+    grouped = defaultdict(list)
+    for row in rows:
+        grouped[float(row["update_fraction"])].append(row)
+
+    fractions = {}
+    crossover = None
+    for fraction in sorted(grouped):
+        group = grouped[fraction]
+        incremental = [int(row["incremental_ns"]) for row in group]
+        full = [int(row["full_recompute_ns"]) for row in group]
+        speedups = [float(row["speedup"]) for row in group]
+        changed = [int(row["changed_edges"]) for row in group]
+        requested = [int(row["requested_edges"]) for row in group]
+        median_speedup = statistics.median(speedups)
+        key = format(fraction, ".12g")
+        fractions[key] = {
+            "samples": len(group),
+            "requested_edges": {
+                "min": min(requested),
+                "median": statistics.median(requested),
+                "max": max(requested),
+            },
+            "actual_changed_edges": {
+                "min": min(changed),
+                "median": statistics.median(changed),
+                "max": max(changed),
+            },
+            "median_incremental_ns": statistics.median(incremental),
+            "p95_incremental_ns": p95(incremental),
+            "median_full_recompute_ns": statistics.median(full),
+            "p95_full_recompute_ns": p95(full),
+            "median_speedup": median_speedup,
+            "p95_speedup": p95(speedups),
+            "correctness_rate": 1.0,
+        }
+        if crossover is None and median_speedup <= 1.0:
+            crossover = fraction
+
+    vertex_counts = {int(row["vertices"]) for row in rows}
+    base_edges = {int(row["base_edges"]) for row in rows}
+    if len(vertex_counts) != 1 or len(base_edges) != 1:
+        raise ValueError("graph size changed within campaign")
+    repeats = {len(group) for group in grouped.values()}
+    if len(repeats) != 1 or next(iter(repeats)) < 2:
+        raise ValueError("every fraction must have repeated measurements")
+
+    summary = {
+        "schema_version": 1,
+        "artifact_type": "velographx-multi-dataset-update-crossover-summary",
+        "dataset": args.dataset,
+        "family": args.family,
+        "research_claim": False,
+        "vertices": next(iter(vertex_counts)),
+        "base_edges": next(iter(base_edges)),
+        "repeats_per_fraction": next(iter(repeats)),
+        "all_incremental_results_match_full_recompute": True,
+        "crossover": {
+            "observed": crossover is not None,
+            "first_fraction_with_median_speedup_le_1": crossover,
+            "conclusion": (
+                f"median incremental speedup reached <=1 at update fraction {crossover}"
+                if crossover is not None
+                else "no crossover observed in the configured update-fraction sweep"
+            ),
+        },
+        "fractions": fractions,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements Issue #4 by generalizing the public incremental triangle crossover campaign beyond ca-GrQc.

- adds three immutable public dataset sources covering collaboration, dense social, and peer-to-peer network structures
- verifies source revision and Git blob identity before use, then records SHA-256 provenance
- runs 5 repeats across 13 update fractions through 200% updates
- preserves exact incremental-vs-full triangle correctness for every sample
- records requested vs actual changed edges
- emits median and p95 timing/speedup statistics plus per-dataset crossover/no-crossover conclusions
- captures hosted-runner environment and validates provenance-rich result bundles
- uploads machine-readable per-dataset evidence artifacts
- documents that hosted CI remains `research_claim=false` engineering evidence, not publication-grade performance

Closes #4 when merged, subject to CI passing.