### PR TITLE
bench: define publication-grade controlled-hardware campaign

### DIFF
--- a/.github/workflows/publication-readiness.yml
+++ b/.github/workflows/publication-readiness.yml
@@ -1,0 +1,50 @@
+name: Publication Readiness Contract
+
+on:
+  push:
+    paths:
+      - '.github/workflows/publication-readiness.yml'
+      - 'benchmarks/publication-hardware-plan.json'
+      - 'tools/validate_publication_readiness.py'
+      - 'docs/publication-hardware-methodology.md'
+      - 'benchmarks/competitor-research-plan.json'
+      - 'datasets/public-research-plan.json'
+  pull_request:
+    paths:
+      - '.github/workflows/publication-readiness.yml'
+      - 'benchmarks/publication-hardware-plan.json'
+      - 'tools/validate_publication_readiness.py'
+      - 'docs/publication-hardware-methodology.md'
+      - 'benchmarks/competitor-research-plan.json'
+      - 'datasets/public-research-plan.json'
+  workflow_dispatch:
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Validate publication hardware contract
+        run: |
+          python tools/validate_publication_readiness.py \
+            benchmarks/publication-hardware-plan.json \
+            > publication-readiness-validation.json
+      - name: Verify claim gate remains closed without controlled-hardware evidence
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path('publication-readiness-validation.json').read_text())
+          assert report['valid'] is True
+          assert report['publication_ready'] is False
+          assert report['allow_publication_claims'] is False
+          PY
+      - name: Upload contract validation
+        uses: actions/upload-artifact@v4
+        with:
+          name: velographx-publication-readiness-contract
+          path: publication-readiness-validation.json
+          retention-days: 30

--- a/benchmarks/publication-hardware-plan.json
+++ b/benchmarks/publication-hardware-plan.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "artifact_type": "velographx-publication-hardware-plan",
+  "research_claim": false,
+  "publication_ready": false,
+  "purpose": "Gate publication-grade performance claims on controlled hardware, immutable provenance, correctness, repeated measurements, and pinned competitors.",
+  "hardware": {
+    "dedicated_machine_required": true,
+    "linux_required": true,
+    "required_metadata": [
+      "cpu_model",
+      "sockets",
+      "physical_cores",
+      "logical_cpus",
+      "smt_state",
+      "numa_nodes",
+      "memory_bytes",
+      "memory_channels_or_platform_description",
+      "kernel",
+      "compiler",
+      "compiler_version",
+      "build_type",
+      "build_flags",
+      "cpu_governor_or_frequency_policy",
+      "affinity_policy"
+    ],
+    "genuine_numa_required_for_numa_claims": true
+  },
+  "experiments": {
+    "thread_scaling": {
+      "required": true,
+      "threads": [1, 2, 4, 8, 16, 32],
+      "extend_to_all_physical_cores_when_above_32": true,
+      "minimum_repeats": 10,
+      "warmup_runs": 2
+    },
+    "numa": {
+      "required_for_numa_claims": true,
+      "policies": ["local", "interleave", "cross-node"],
+      "minimum_repeats": 10,
+      "requires_at_least_two_numa_nodes": true
+    },
+    "hardware_counters": {
+      "required": true,
+      "preferred_events": [
+        "cycles",
+        "instructions",
+        "branches",
+        "branch-misses",
+        "cache-references",
+        "cache-misses",
+        "LLC-loads",
+        "LLC-load-misses"
+      ],
+      "memory_traffic_or_remote_numa_events_when_supported": true
+    },
+    "update_fraction": {
+      "required": true,
+      "minimum_repeats": 10,
+      "correctness_match_required_for_every_sample": true
+    },
+    "ablations": {
+      "required": true,
+      "dimensions": [
+        "incremental-vs-full",
+        "adaptive-vs-fixed-policy",
+        "scalar-vs-simd",
+        "compression-on-vs-off",
+        "work-stealing-on-vs-off",
+        "numa-policy"
+      ]
+    },
+    "competitors": {
+      "required": true,
+      "same_hardware_required": true,
+      "linked_plan": "benchmarks/competitor-research-plan.json",
+      "priority_native": ["SuiteSparse:GraphBLAS/LAGraph", "GAP Benchmark Suite"]
+    }
+  },
+  "datasets": {
+    "immutable_provenance_required": true,
+    "checksums_required": true,
+    "linked_plan": "datasets/public-research-plan.json",
+    "minimum_distinct_graph_families": 3
+  },
+  "statistics": {
+    "raw_samples_required": true,
+    "median_required": true,
+    "p95_required": true,
+    "uncertainty_summary_required": true,
+    "requested_vs_actual_work_required": true
+  },
+  "artifacts": {
+    "machine_readable_csv_or_json_required": true,
+    "environment_capture_required": true,
+    "validated_result_bundle_required": true
+  },
+  "claim_gate": {
+    "all_requirements_must_pass": true,
+    "hosted_ci_alone_is_publication_grade": false,
+    "unresolved_competitor_pins_block_comparative_claims": true,
+    "missing_genuine_numa_hardware_blocks_numa_claims": true,
+    "failed_correctness_blocks_performance_claims": true,
+    "allow_publication_claims": false
+  }
+}

--- a/docs/publication-hardware-methodology.md
+++ b/docs/publication-hardware-methodology.md
@@ -1,0 +1,47 @@
+# Publication-grade controlled-hardware methodology
+
+VeloGraphX distinguishes **hosted-CI engineering evidence** from **publication-grade performance evidence**. The existing GitHub-hosted campaigns validate correctness, reproducibility contracts, benchmark plumbing, artifact schemas, and useful crossover behavior, but they do not by themselves justify claims about dedicated-hardware scalability, NUMA efficiency, or superiority over other graph systems.
+
+`benchmarks/publication-hardware-plan.json` is the machine-readable claim gate for publication-grade experiments. The repository copy intentionally keeps `publication_ready=false` and `allow_publication_claims=false` until real controlled-hardware evidence exists.
+
+## Hardware readiness
+
+Publication-grade measurements require a dedicated Linux machine. Record the CPU model, socket count, physical cores, logical CPUs, SMT state, NUMA topology, installed memory, platform/memory-channel description, kernel, compiler and version, build type/flags, CPU governor or frequency policy, and affinity policy.
+
+NUMA claims require genuine hardware with at least two NUMA nodes. A single-socket or synthetic topology may still be used for general correctness and scaling work, but it must not be used to claim cross-socket NUMA benefit.
+
+## Measurement protocol
+
+Run at least two warmups before timed measurements. Use at least ten measured repetitions per configuration for publication tables. Preserve raw samples, then report medians, p95 values, and an uncertainty summary. Record requested work and actual changed work for incremental campaigns.
+
+Thread scaling must include 1, 2, 4, 8, 16, and 32 threads when supported, and should extend to all physical cores on larger machines. Affinity must be explicit and reproducible. If SMT is evaluated, report physical-core and logical-thread scaling separately.
+
+NUMA evaluation should include local placement, interleaved placement, and a deliberately cross-node configuration. Capture locality/remote-memory events where the platform exposes reliable counters.
+
+Hardware-counter experiments should record cycles, instructions, branches, branch misses, cache references/misses, LLC loads/misses, and memory-traffic or remote-NUMA events when supported. Missing platform events must be reported as unavailable rather than silently omitted.
+
+## Correctness gate
+
+Performance evidence is invalid when correctness fails. Every incremental result used in a performance comparison must match the corresponding full/reference result under the repository's exact correctness contract. Competitor results must use semantically equivalent graph interpretation and normalized inputs.
+
+## Datasets
+
+Use public datasets with immutable provenance and checksums. The controlled-hardware campaign should cover at least three distinct graph families and should include larger datasets than the hosted-CI smoke/evidence campaigns where memory permits. Dataset preparation, normalization, and checksums must be captured in the result bundle.
+
+## Competitors
+
+Comparative claims require competitors to run on the **same hardware** under recorded software versions/builds. `benchmarks/competitor-research-plan.json` is authoritative for competitor readiness. Native `SuiteSparse:GraphBLAS/LAGraph` and the `GAP Benchmark Suite` are priority CPU-system comparisons. Floating branches such as `main`, `master`, or `HEAD` are not valid publication identities.
+
+Package-level competitors such as NetworKit, igraph, rustworkx, and NetworkX can provide additional context, but native CPU graph systems are the more important comparison for systems claims.
+
+## Ablations
+
+Publication evidence should isolate where speedups come from. Required ablation dimensions include incremental versus full recomputation, adaptive versus fixed policy, scalar versus SIMD, compression enabled/disabled, work stealing enabled/disabled, and NUMA policy where applicable.
+
+## Artifacts and claims
+
+Each experiment must produce machine-readable raw results, environment metadata, provenance, summary statistics, and a validated result bundle. The exact commit used for the run must be recorded.
+
+Until the readiness validator can be run against a real filled execution record with the publication gate explicitly opened, README and paper text should use wording such as **engineering evidence**, **hosted-CI result**, or **controlled-hardware measurement pending**. Do not convert hosted-CI speedups into publication-grade scalability or superiority claims.
+
+The eventual execution of this plan is tracked separately from the contract itself so that the repository never fabricates dedicated-hardware evidence merely to satisfy a checklist.

--- a/tools/validate_publication_readiness.py
+++ b/tools/validate_publication_readiness.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate the VeloGraphX publication-hardware campaign contract.")
+    parser.add_argument("plan", type=Path)
+    parser.add_argument("--expect-ready", action="store_true", help="Require the publication claim gate to be open.")
+    args = parser.parse_args()
+
+    data = json.loads(args.plan.read_text(encoding="utf-8"))
+    require(data.get("schema_version") == 1, "unsupported schema_version")
+    require(data.get("artifact_type") == "velographx-publication-hardware-plan", "unexpected artifact_type")
+
+    hardware = data["hardware"]
+    require(hardware["dedicated_machine_required"] is True, "dedicated hardware must be required")
+    require(hardware["linux_required"] is True, "Linux must be required")
+    metadata = set(hardware["required_metadata"])
+    for field in {"cpu_model", "sockets", "physical_cores", "logical_cpus", "numa_nodes", "memory_bytes", "compiler", "compiler_version", "kernel", "build_flags", "affinity_policy"}:
+        require(field in metadata, f"missing hardware metadata field: {field}")
+
+    experiments = data["experiments"]
+    threads = experiments["thread_scaling"]["threads"]
+    require(threads[:6] == [1, 2, 4, 8, 16, 32], "thread scaling must cover 1/2/4/8/16/32")
+    require(experiments["thread_scaling"]["minimum_repeats"] >= 10, "thread scaling needs at least 10 repeats")
+    require(experiments["numa"]["requires_at_least_two_numa_nodes"] is True, "NUMA claims require >=2 NUMA nodes")
+    require("cross-node" in experiments["numa"]["policies"], "NUMA plan must include cross-node placement")
+    require(experiments["hardware_counters"]["required"] is True, "hardware counters must be required")
+    require(experiments["ablations"]["required"] is True, "ablations must be required")
+    require(experiments["competitors"]["same_hardware_required"] is True, "competitors must run on same hardware")
+    require("LAGraph" in " ".join(experiments["competitors"]["priority_native"]), "LAGraph/GraphBLAS must be a priority competitor")
+    require("GAP Benchmark Suite" in experiments["competitors"]["priority_native"], "GAP must be a priority competitor")
+
+    datasets = data["datasets"]
+    require(datasets["immutable_provenance_required"] is True, "dataset provenance must be immutable")
+    require(datasets["checksums_required"] is True, "dataset checksums must be required")
+    require(datasets["minimum_distinct_graph_families"] >= 3, "at least three graph families are required")
+
+    stats = data["statistics"]
+    require(stats["raw_samples_required"] is True, "raw samples must be retained")
+    require(stats["median_required"] is True and stats["p95_required"] is True, "median and p95 must be reported")
+    require(stats["uncertainty_summary_required"] is True, "uncertainty summary must be required")
+
+    artifacts = data["artifacts"]
+    require(artifacts["environment_capture_required"] is True, "environment capture is required")
+    require(artifacts["validated_result_bundle_required"] is True, "validated result bundle is required")
+
+    gate = data["claim_gate"]
+    require(gate["hosted_ci_alone_is_publication_grade"] is False, "hosted CI must not be publication grade")
+    require(gate["failed_correctness_blocks_performance_claims"] is True, "correctness failure must block claims")
+    if args.expect_ready:
+        require(data.get("publication_ready") is True, "publication_ready is false")
+        require(gate["allow_publication_claims"] is True, "publication claim gate is closed")
+    else:
+        require(data.get("publication_ready") is False, "contract fixture must remain not-ready until real hardware evidence exists")
+        require(gate["allow_publication_claims"] is False, "publication claims must remain disabled in the repository fixture")
+
+    print(json.dumps({
+        "schema_version": 1,
+        "artifact_type": "velographx-publication-readiness-validation",
+        "valid": True,
+        "publication_ready": data["publication_ready"],
+        "allow_publication_claims": gate["allow_publication_claims"]
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the execution-contract portion of Issue #9.

- adds a machine-readable publication hardware plan with an explicit closed claim gate
- requires dedicated Linux hardware and complete CPU/socket/core/SMT/NUMA/memory/compiler metadata
- requires 1/2/4/8/16/32+ thread scaling where supported and genuine >=2-node NUMA hardware for NUMA claims
- requires >=10 measured repetitions, warmups, raw samples, median/p95 and uncertainty summaries
- requires hardware counters, ablations, immutable dataset provenance and validated result bundles
- requires same-hardware competitor comparisons with native LAGraph/GraphBLAS and GAP prioritized
- adds a readiness validator that deliberately fails publication-ready mode until real execution evidence exists
- adds CI to prevent accidental weakening/opening of the publication claim gate
- documents methodology and the separation between hosted-CI engineering evidence and publication-grade results

Closes #11 when merged. Advances #9; actual controlled-hardware measurements remain separately tracked in #10.