### PR TITLE
bench: add hosted-CI baseline for issue 10

### DIFF
--- a/.github/workflows/hosted-ci-baseline.yml
+++ b/.github/workflows/hosted-ci-baseline.yml
@@ -1,0 +1,77 @@
+name: Hosted CPU Baseline Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'benchmarks/campaigns/hosted_ci_baseline.json'
+      - 'tools/run_hosted_ci_baseline.py'
+      - '.github/workflows/hosted-ci-baseline.yml'
+      - 'docs/hosted-ci-baseline.md'
+  workflow_dispatch:
+
+jobs:
+  hosted-baseline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install competitor dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install 'networkx==3.4.2' 'igraph==0.11.8' 'networkit==11.1' 'rustworkx==0.16.0'
+      - name: Build benchmarks
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DVELOGRAPHX_BUILD_TESTS=ON -DVELOGRAPHX_BUILD_BENCHMARKS=ON
+          cmake --build build --parallel 2
+          ctest --test-dir build --output-on-failure
+      - name: Create deterministic baseline graph
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          n = 1000
+          edges = set()
+          for u in range(n):
+              for delta in (1, 7, 31):
+                  v = (u + delta) % n
+                  edges.add((min(u, v), max(u, v)))
+          path = Path('artifacts/baseline')
+          path.mkdir(parents=True, exist_ok=True)
+          with (path / 'baseline.edgelist').open('w') as f:
+              for u, v in sorted(edges):
+                  f.write(f'{u} {v}\n')
+          PY
+      - name: Capture environment
+        run: |
+          mkdir -p artifacts/baseline
+          python tools/capture_benchmark_environment.py --output artifacts/baseline/environment.json
+      - name: Execute hosted baseline
+        run: |
+          python tools/run_hosted_ci_baseline.py \
+            --build-dir build \
+            --dataset artifacts/baseline/baseline.edgelist \
+            --output-dir artifacts/baseline
+      - name: Validate claim gate
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          plan = json.loads(Path('benchmarks/campaigns/hosted_ci_baseline.json').read_text())
+          report = json.loads(Path('artifacts/baseline/hosted-ci-baseline.json').read_text())
+          assert plan['research_claim'] is False
+          assert plan['publication_grade'] is False
+          assert plan['claim_gate']['publication_ready'] is False
+          assert report['research_claim'] is False
+          assert report['publication_grade'] is False
+          assert report['claim_gate']['publication_ready'] is False
+          assert report['competitors']
+          assert report['thread_scaling']
+          PY
+      - name: Upload hosted engineering evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: velographx-hosted-ci-baseline
+          path: artifacts/baseline
+          retention-days: 30

--- a/.github/workflows/hosted-ci-baseline.yml
+++ b/.github/workflows/hosted-ci-baseline.yml
@@ -22,6 +22,33 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install 'networkx==3.4.2' 'igraph==0.11.8' 'networkit==11.1' 'rustworkx==0.16.0'
+          NETWORKIT_LIB_DIR="$(python - <<'PY'
+          import site
+          from pathlib import Path
+          candidates = []
+          for root in site.getsitepackages():
+              path = Path(root) / 'networkit'
+              if path.is_dir():
+                  candidates.append(path)
+          if not candidates:
+              raise SystemExit('networkit package directory not found')
+          print(candidates[0])
+          PY
+          )"
+          echo "LD_LIBRARY_PATH=${NETWORKIT_LIB_DIR}:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+          test -f "${NETWORKIT_LIB_DIR}/libnetworkit.so"
+      - name: Verify competitor imports
+        run: |
+          python - <<'PY'
+          import igraph
+          import networkit
+          import networkx
+          import rustworkx
+          print('networkx', networkx.__version__)
+          print('igraph', igraph.__version__)
+          print('networkit', networkit.__version__)
+          print('rustworkx', rustworkx.__version__)
+          PY
       - name: Build benchmarks
         run: |
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DVELOGRAPHX_BUILD_TESTS=ON -DVELOGRAPHX_BUILD_BENCHMARKS=ON

--- a/.github/workflows/hosted-ci-baseline.yml
+++ b/.github/workflows/hosted-ci-baseline.yml
@@ -25,14 +25,13 @@ jobs:
           NETWORKIT_LIB_DIR="$(python - <<'PY'
           import site
           from pathlib import Path
-          candidates = []
-          for root in site.getsitepackages():
-              path = Path(root) / 'networkit'
-              if path.is_dir():
-                  candidates.append(path)
-          if not candidates:
-              raise SystemExit('networkit package directory not found')
-          print(candidates[0])
+          roots = [Path(p) for p in site.getsitepackages()]
+          matches = []
+          for root in roots:
+              matches.extend(root.rglob('libnetworkit.so'))
+          if not matches:
+              raise SystemExit('libnetworkit.so not found under site-packages')
+          print(matches[0].parent)
           PY
           )"
           echo "LD_LIBRARY_PATH=${NETWORKIT_LIB_DIR}:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"

--- a/benchmarks/campaigns/hosted_ci_baseline.json
+++ b/benchmarks/campaigns/hosted_ci_baseline.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "artifact_type": "velographx-hosted-ci-baseline-plan",
+  "research_claim": false,
+  "publication_grade": false,
+  "purpose": "Execute the subset of Issue #10 that is meaningful on GitHub-hosted CPU runners while preserving a strict separation from controlled-hardware publication claims.",
+  "thread_scaling": {
+    "requested_threads": [1, 2, 4],
+    "rule": "Run only thread counts not exceeding the logical CPUs exposed by the runner.",
+    "repeat": 5,
+    "benchmark": "velographx_benchmark"
+  },
+  "ablations": {
+    "suites": ["intersection", "compression", "incremental"],
+    "runner": "tools/ablation_suite.py"
+  },
+  "competitors": {
+    "algorithm": "bfs",
+    "frameworks": ["builtin", "networkx", "igraph", "networkit", "rustworkx"],
+    "repeat": 5,
+    "correctness_rule": "All normalized result digests must match builtin on the same dataset/source.",
+    "native_external_note": "LAGraph/GraphBLAS and GAP remain part of the controlled-hardware phase unless immutable native builds are explicitly provisioned on the same runner."
+  },
+  "perf_counters": {
+    "attempt": true,
+    "events": ["cycles", "instructions", "cache-misses", "branches", "branch-misses"],
+    "rule": "Counter collection is best-effort on hosted runners. Permission denial is recorded as evidence and must not fail the baseline campaign."
+  },
+  "evidence": {
+    "capture_environment": true,
+    "raw_machine_readable_outputs": true,
+    "exact_correctness_required": true,
+    "hosted_runner_caveat_required": true
+  },
+  "claim_gate": {
+    "publication_ready": false,
+    "allowed_claim": "Hosted-CI engineering baseline only.",
+    "forbidden_claims": [
+      "publication-grade scalability",
+      "multi-socket NUMA benefit",
+      "stable 8/16/32+ core scaling",
+      "controlled same-hardware superiority"
+    ]
+  }
+}

--- a/docs/hosted-ci-baseline.md
+++ b/docs/hosted-ci-baseline.md
@@ -1,0 +1,33 @@
+# Hosted CI baseline for Issue #10
+
+This campaign executes the subset of the controlled-hardware benchmark plan that is meaningful on GitHub-hosted CPU runners.
+
+It is **engineering evidence only**. It is not publication-grade performance evidence and does not open the publication claim gate.
+
+## What the hosted baseline measures
+
+- thread-limited benchmark runs at 1, 2, and 4 threads when the runner exposes those logical CPUs;
+- five repeated samples per thread count;
+- paired intersection, compression, and incremental ablation suites;
+- same-runner BFS comparisons across the builtin reference, NetworkX, igraph, NetworKit, and rustworkx;
+- exact normalized result-digest agreement against the builtin reference;
+- a best-effort Linux `perf stat` attempt for cycles, instructions, cache misses, branches, and branch misses;
+- environment metadata and raw machine-readable outputs.
+
+If the hosted runner denies access to hardware performance counters, the campaign records that limitation rather than treating it as a benchmark failure.
+
+## Claims that remain prohibited
+
+Hosted results must not be described as evidence for:
+
+- publication-grade scalability;
+- stable 8/16/32+ core scaling;
+- genuine multi-socket NUMA locality or remote-memory effects;
+- controlled same-hardware superiority over native research systems;
+- production hardware performance.
+
+Those claims remain blocked on the dedicated-hardware phase of Issue #10.
+
+## Why this is useful
+
+The hosted baseline validates the campaign plumbing, correctness contracts, repeat structure, competitor normalization, artifact generation, and the ability to collect whatever hardware-sensitive metadata the runner permits. The same methodology can later be rerun on dedicated hardware without changing the evidence rules.

--- a/docs/issue-10-phases.md
+++ b/docs/issue-10-phases.md
@@ -1,0 +1,15 @@
+# Issue #10 execution phases
+
+## Phase A — hosted CI baseline
+
+Status: feasible on GitHub-hosted runners.
+
+Produces engineering evidence for limited thread scaling, paired ablations, same-runner Python/native-core competitor comparisons, correctness normalization, environment capture, and best-effort hardware counters. The publication claim gate remains closed.
+
+## Phase B — dedicated controlled hardware
+
+Status: blocked on suitable hardware.
+
+Requires dedicated Linux hardware, 8/16/32+ cores where available, genuine NUMA/multi-socket topology for NUMA claims, stable frequency/affinity controls, hardware counters, pinned native LAGraph/GraphBLAS and GAP builds, repeated public-dataset campaigns, and validated publication result bundles.
+
+Phase A is intentionally designed to validate the measurement machinery before Phase B. Phase A completion does not complete Issue #10.

--- a/tools/run_hosted_ci_baseline.py
+++ b/tools/run_hosted_ci_baseline.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+THREADS = [1, 2, 4]
+FRAMEWORKS = ["builtin", "networkx", "igraph", "networkit", "rustworkx"]
+
+
+def run(cmd, *, allow_failure=False):
+    proc = subprocess.run(cmd, text=True, capture_output=True, check=False)
+    if proc.returncode != 0 and not allow_failure:
+        raise RuntimeError(f"command failed ({proc.returncode}): {' '.join(cmd)}\n{proc.stderr or proc.stdout}")
+    return {"argv": cmd, "returncode": proc.returncode, "stdout": proc.stdout.strip(), "stderr": proc.stderr.strip()}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-dir", type=Path, default=Path("build"))
+    parser.add_argument("--dataset", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    cpu_count = os.cpu_count() or 1
+    report = {
+        "schema_version": 1,
+        "kind": "hosted-ci-baseline",
+        "research_claim": False,
+        "publication_grade": False,
+        "cpu_count": cpu_count,
+        "thread_scaling": [],
+        "competitors": {},
+        "ablation": None,
+        "perf": None,
+    }
+
+    bench = args.build_dir / "velographx_benchmark"
+    for threads in [t for t in THREADS if t <= cpu_count]:
+        samples = []
+        for _ in range(5):
+            result = run([sys.executable, "tools/hardware_campaign_driver.py", "--threads", str(threads), "--", str(bench)])
+            samples.append(json.loads(result["stdout"]))
+        report["thread_scaling"].append({"threads": threads, "samples": samples})
+
+    ablation_path = args.output_dir / "ablation.json"
+    run([sys.executable, "tools/ablation_suite.py", "--build-dir", str(args.build_dir), "--output", str(ablation_path)])
+    report["ablation"] = json.loads(ablation_path.read_text())
+
+    reference_digest = None
+    for framework in FRAMEWORKS:
+        out = args.output_dir / f"competitor-{framework}.json"
+        result = run([
+            sys.executable, "tools/competitor_benchmark.py",
+            "--dataset", str(args.dataset),
+            "--framework", framework,
+            "--algorithm", "bfs",
+            "--source", "0",
+            "--repeat", "5",
+            "--output", str(out),
+        ])
+        payload = json.loads(out.read_text())
+        digest = payload.get("result_digest")
+        if framework == "builtin":
+            reference_digest = digest
+        elif digest != reference_digest:
+            raise RuntimeError(f"correctness digest mismatch for {framework}")
+        report["competitors"][framework] = payload
+
+    perf_result = run([
+        sys.executable, "tools/hardware_campaign_driver.py",
+        "--threads", "1",
+        "--perf",
+        "--perf-events", "cycles,instructions,cache-misses,branches,branch-misses",
+        "--", str(bench),
+    ], allow_failure=True)
+    if perf_result["returncode"] == 0:
+        report["perf"] = {"status": "available", "result": json.loads(perf_result["stdout"])}
+    else:
+        report["perf"] = {"status": "unavailable-or-denied", "returncode": perf_result["returncode"], "stderr": perf_result["stderr"], "stdout": perf_result["stdout"]}
+
+    report["claim_gate"] = {
+        "publication_ready": False,
+        "allowed_claim": "Hosted-CI engineering baseline only.",
+    }
+    (args.output_dir / "hosted-ci-baseline.json").write_text(json.dumps(report, sort_keys=True, indent=2) + "\n")
+    print(json.dumps({"ok": True, "cpu_count": cpu_count, "threads_tested": [x["threads"] for x in report["thread_scaling"]], "perf_status": report["perf"]["status"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
## Summary

Implements Phase A of Issue #10 using the hardware that is actually available on GitHub-hosted CI.

- adds a machine-readable hosted-CI baseline plan with `research_claim=false` and `publication_grade=false`
- runs 1/2/4-thread cases only when the runner exposes those CPUs, with 5 repeats per thread count
- executes existing intersection, compression, and incremental ablation suites
- compares builtin BFS against NetworkX, igraph, NetworKit, and rustworkx on the same deterministic graph
- requires exact result-digest agreement for every competitor
- attempts Linux perf counters but records permission denial as a limitation rather than fabricating data
- captures environment metadata and uploads raw machine-readable evidence
- documents Phase A hosted evidence vs Phase B dedicated-hardware requirements
- keeps the publication claim gate explicitly closed

This does not close Issue #10. Dedicated 8/16/32+ scaling, genuine multi-socket NUMA, and controlled native LAGraph/GraphBLAS/GAP measurements remain Phase B.