### PR TITLE
chore: prepare v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.7.0 - 2026-08-28
+
+- Added reproducible hosted-CI benchmark evidence with explicit non-publication claim gates.
+- Added multi-dataset incremental crossover campaigns with immutable dataset provenance, exact correctness checks, repeated statistics, and machine-readable artifacts.
+- Added publication-grade controlled-hardware campaign contracts covering thread scaling, genuine NUMA placement, hardware counters, ablations, competitor pinning, and readiness validation.
+- Added public-dataset verification and pinned benchmark metadata, including web-Google planning and smaller public graph campaigns.
+- Added configurable update-fraction sweeps for incremental-vs-recompute crossover analysis.
+- Expanded CI validation for benchmark contracts, publication readiness, public datasets, and hosted engineering evidence.
+- Aligned README and limitations documentation with currently implemented and validated capabilities.
+- Preserved a strict distinction between hosted-CI engineering evidence and future controlled-hardware publication claims.
+
 ## 0.3.0 - 2026-08-26
 
 - Added versioned CSR+delta dynamic graph storage with batch updates and compaction.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,5 +7,5 @@ authors:
     given-names: Saurav
 repository-code: "https://github.com/sauravsingla/VeloGraphX"
 license: Apache-2.0
-version: 0.1.0
-date-released: 2026-08-26
+version: 0.7.0
+date-released: 2026-08-28

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(VeloGraphX VERSION 0.6.5 LANGUAGES CXX)
+project(VeloGraphX VERSION 0.7.0 LANGUAGES CXX)
 
 option(VELOGRAPHX_BUILD_TESTS "Build tests" ON)
 option(VELOGRAPHX_BUILD_BENCHMARKS "Build benchmarks" ON)


### PR DESCRIPTION
## Summary

Prepares VeloGraphX v0.7.0 after the benchmark-contract and hosted-CI evidence work landed.

- bumps the CMake project version from 0.6.5 to 0.7.0
- updates `CITATION.cff` to v0.7.0 with the 2026-08-28 release date
- adds a v0.7.0 changelog section covering reproducible hosted-CI evidence, multi-dataset crossover campaigns, publication-readiness contracts, public dataset provenance, configurable update-fraction sweeps, and documentation alignment
- keeps publication-grade performance claims explicitly gated on dedicated controlled hardware

Closes #12 once merged and the GitHub release/tag is created.