### PR TITLE
bench: add Issue #10 controlled-hardware campaign runner

### DIFF
--- a/docs/controlled-hardware-execution.md
+++ b/docs/controlled-hardware-execution.md
@@ -1,0 +1,50 @@
+# Controlled-hardware execution for Issue #10
+
+This is the Phase B execution entry point for publication-grade CPU measurements. It composes the existing single-case `hardware_campaign_driver.py` into repeated thread-scaling, NUMA and hardware-counter cases while preserving the repository claim gate.
+
+## Preconditions
+
+Use a dedicated Linux machine. For the full campaign, the host should expose at least 32 logical/physical execution slots appropriate for the benchmark, `taskset`, `numactl`, and Linux `perf`. NUMA claims require at least two genuine NUMA nodes. Keep CPU governor/frequency, SMT policy, compiler, build flags, kernel, dataset checksums and competitor revisions fixed and recorded.
+
+Build the benchmark in release mode before collecting measurements.
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+```
+
+## Thread scaling + counters + NUMA
+
+Example invocation:
+
+```bash
+python3 tools/run_controlled_hardware_campaign.py \
+  --threads 1,2,4,8,16,32 \
+  --repeats 10 \
+  --warmups 2 \
+  --perf \
+  --numa \
+  --output controlled-hardware-results.json \
+  -- ./build/velographx_benchmark_public_dataset <dataset.edgelist> 0
+```
+
+The orchestrator automatically skips requested thread counts above the detected CPU count and records that fact. It records per-sample wall time plus the complete low-level driver output. NUMA cases are only executed when at least two NUMA nodes are detected.
+
+## Claim gate
+
+The resulting artifact contains both `publication_ready` and `research_claim`, but the runner deliberately keeps `claim_gate.allow_publication_claims` false. A successful hardware run is necessary but not sufficient for comparative publication claims.
+
+Before publishing performance claims, also require:
+
+- immutable public dataset provenance and checksums;
+- exact correctness validation for every compared result;
+- pinned same-hardware native LAGraph/GraphBLAS and GAP executions;
+- validated result bundles and environment capture;
+- required ablations and update-fraction campaigns;
+- repository publication-readiness validators passing on the final evidence bundle.
+
+Hosted GitHub Actions results remain engineering evidence and must not be relabeled as controlled-hardware publication results.
+
+## Expected evidence
+
+For a complete Phase B package, retain the raw JSON output, environment capture, benchmark build metadata, competitor version/build records, correctness digests, raw competitor samples, public-dataset provenance and all summary artifacts. Issue #10 should remain open until those measurements are actually produced on suitable hardware and pass validation.

--- a/tools/hardware_campaign_driver.py
+++ b/tools/hardware_campaign_driver.py
@@ -7,7 +7,6 @@ import shutil
 import subprocess
 import sys
 import time
-from pathlib import Path
 
 
 def build_command(args):
@@ -29,6 +28,10 @@ def build_command(args):
             wrappers += [numactl, f"--cpunodebind={args.numa_node}", f"--membind={args.numa_node}"]
         elif args.numa_policy == "interleave":
             wrappers += [numactl, "--interleave=all"]
+        elif args.numa_policy == "cross-node":
+            if args.numa_cpu_node == args.numa_mem_node:
+                raise ValueError("cross-node policy requires different CPU and memory nodes")
+            wrappers += [numactl, f"--cpunodebind={args.numa_cpu_node}", f"--membind={args.numa_mem_node}"]
 
     if args.perf:
         perf = shutil.which("perf")
@@ -43,8 +46,10 @@ def build_command(args):
 def main():
     parser = argparse.ArgumentParser(description="Run one VeloGraphX hardware-sensitive benchmark case reproducibly.")
     parser.add_argument("--threads", type=int, default=1)
-    parser.add_argument("--numa-policy", choices=("none", "local", "interleave"), default="none")
+    parser.add_argument("--numa-policy", choices=("none", "local", "interleave", "cross-node"), default="none")
     parser.add_argument("--numa-node", type=int, default=0)
+    parser.add_argument("--numa-cpu-node", type=int, default=0)
+    parser.add_argument("--numa-mem-node", type=int, default=1)
     parser.add_argument("--perf", action="store_true")
     parser.add_argument("--perf-events")
     parser.add_argument("--timeout-seconds", type=float, default=600)
@@ -64,14 +69,7 @@ def main():
     env["OMP_NUM_THREADS"] = str(args.threads)
 
     started = time.perf_counter()
-    completed = subprocess.run(
-        command,
-        env=env,
-        text=True,
-        capture_output=True,
-        timeout=args.timeout_seconds,
-        check=False,
-    )
+    completed = subprocess.run(command, env=env, text=True, capture_output=True, timeout=args.timeout_seconds, check=False)
     elapsed = time.perf_counter() - started
 
     report = {
@@ -79,6 +77,8 @@ def main():
         "threads": args.threads,
         "numa_policy": args.numa_policy,
         "numa_node": args.numa_node if args.numa_policy == "local" else None,
+        "numa_cpu_node": args.numa_cpu_node if args.numa_policy == "cross-node" else None,
+        "numa_mem_node": args.numa_mem_node if args.numa_policy == "cross-node" else None,
         "perf_enabled": args.perf,
         "perf_events": args.perf_events,
         "argv": command,

--- a/tools/run_controlled_hardware_campaign.py
+++ b/tools/run_controlled_hardware_campaign.py
@@ -15,12 +15,7 @@ DEFAULT_PERF_EVENTS = "cycles,instructions,branches,branch-misses,cache-referenc
 
 def run(cmd, timeout):
     completed = subprocess.run(cmd, text=True, capture_output=True, timeout=timeout, check=False)
-    return {
-        "argv": cmd,
-        "returncode": completed.returncode,
-        "stdout": completed.stdout.strip(),
-        "stderr": completed.stderr.strip(),
-    }
+    return {"argv": cmd, "returncode": completed.returncode, "stdout": completed.stdout.strip(), "stderr": completed.stderr.strip()}
 
 
 def detect_numa_nodes():
@@ -29,15 +24,13 @@ def detect_numa_nodes():
     probe = subprocess.run(["numactl", "--hardware"], text=True, capture_output=True, check=False)
     if probe.returncode != 0:
         return []
-    nodes = []
     for line in probe.stdout.splitlines():
         if line.startswith("available:") and "nodes" in line:
             try:
-                count = int(line.split()[1])
-                nodes = list(range(count))
+                return list(range(int(line.split()[1])))
             except (ValueError, IndexError):
-                pass
-    return nodes
+                return []
+    return []
 
 
 def parse_driver_report(result):
@@ -53,22 +46,16 @@ def parse_driver_report(result):
 
 
 def summarize(samples):
-    values = [sample["wall_seconds"] for sample in samples if sample.get("returncode") == 0]
+    values = [sample["wall_seconds"] for sample in samples if sample.get("returncode") == 0 and sample.get("wall_seconds") is not None]
     if not values:
         return {"n": 0}
     ordered = sorted(values)
     p95_index = min(len(ordered) - 1, max(0, int(round(0.95 * (len(ordered) - 1)))))
-    return {
-        "n": len(values),
-        "median_wall_seconds": statistics.median(values),
-        "p95_wall_seconds": ordered[p95_index],
-        "min_wall_seconds": min(values),
-        "max_wall_seconds": max(values),
-    }
+    return {"n": len(values), "median_wall_seconds": statistics.median(values), "p95_wall_seconds": ordered[p95_index], "min_wall_seconds": min(values), "max_wall_seconds": max(values)}
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Execute VeloGraphX publication-grade controlled-hardware campaign cases.")
+    parser = argparse.ArgumentParser(description="Execute VeloGraphX controlled-hardware campaign cases.")
     parser.add_argument("--output", default="controlled-hardware-results.json")
     parser.add_argument("--repeats", type=int, default=10)
     parser.add_argument("--warmups", type=int, default=2)
@@ -89,44 +76,47 @@ def main():
         raise ValueError("benchmark command is required after --")
 
     threads = sorted(set(int(x) for x in args.threads.split(",") if x.strip()))
+    if any(t < 1 for t in threads):
+        raise ValueError("thread counts must be positive")
     cpu_count = os.cpu_count() or 1
     executable_threads = [t for t in threads if t <= cpu_count]
     skipped_threads = [t for t in threads if t > cpu_count]
     numa_nodes = detect_numa_nodes()
-
     driver = str(Path(__file__).with_name("hardware_campaign_driver.py"))
     cases = []
 
-    def execute_case(kind, thread_count, numa_policy="none", numa_node=0, perf=False):
+    def execute_case(kind, thread_count, numa_policy="none", numa_node=0, numa_cpu_node=0, numa_mem_node=1, perf=False):
         base = [sys.executable, driver, "--threads", str(thread_count), "--numa-policy", numa_policy]
         if numa_policy == "local":
             base += ["--numa-node", str(numa_node)]
+        elif numa_policy == "cross-node":
+            base += ["--numa-cpu-node", str(numa_cpu_node), "--numa-mem-node", str(numa_mem_node)]
         if perf:
             base += ["--perf", "--perf-events", args.perf_events]
         base += ["--timeout-seconds", str(args.timeout_seconds), "--"] + command
 
+        warmup_failed = False
         for _ in range(args.warmups):
             warm = run(base, args.timeout_seconds + 30)
             if warm["returncode"] != 0:
+                warmup_failed = True
                 break
 
         samples = []
         for _ in range(args.repeats):
             result = run(base, args.timeout_seconds + 30)
             report = parse_driver_report(result)
-            samples.append(report or {
-                "returncode": result["returncode"],
-                "wall_seconds": None,
-                "stdout": result["stdout"],
-                "stderr": result["stderr"],
-            })
+            samples.append(report or {"returncode": result["returncode"], "wall_seconds": None, "stdout": result["stdout"], "stderr": result["stderr"]})
 
         cases.append({
             "kind": kind,
             "threads": thread_count,
             "numa_policy": numa_policy,
             "numa_node": numa_node if numa_policy == "local" else None,
+            "numa_cpu_node": numa_cpu_node if numa_policy == "cross-node" else None,
+            "numa_mem_node": numa_mem_node if numa_policy == "cross-node" else None,
             "perf": perf,
+            "warmup_failed": warmup_failed,
             "summary": summarize(samples),
             "samples": samples,
         })
@@ -135,8 +125,7 @@ def main():
         execute_case("thread_scaling", t)
 
     if args.perf:
-        perf_thread = max(executable_threads) if executable_threads else 1
-        execute_case("hardware_counters", perf_thread, perf=True)
+        execute_case("hardware_counters", max(executable_threads) if executable_threads else 1, perf=True)
 
     if args.numa:
         if len(numa_nodes) >= 2:
@@ -144,29 +133,24 @@ def main():
             execute_case("numa_local", peak_threads, numa_policy="local", numa_node=numa_nodes[0])
             execute_case("numa_local", peak_threads, numa_policy="local", numa_node=numa_nodes[1])
             execute_case("numa_interleave", peak_threads, numa_policy="interleave")
+            execute_case("numa_cross_node", peak_threads, numa_policy="cross-node", numa_cpu_node=numa_nodes[0], numa_mem_node=numa_nodes[1])
         else:
             cases.append({"kind": "numa", "skipped": True, "reason": "fewer than two genuine NUMA nodes detected"})
 
     all_measured = [case for case in cases if not case.get("skipped")]
-    all_success = all(case.get("summary", {}).get("n", 0) == args.repeats for case in all_measured)
+    all_success = bool(all_measured) and all(case.get("summary", {}).get("n", 0) == args.repeats and not case.get("warmup_failed", False) for case in all_measured)
     required_threads_present = all(t in executable_threads for t in DEFAULT_THREADS)
     numa_ready = (not args.numa) or len(numa_nodes) >= 2
     perf_ready = (not args.perf) or shutil.which("perf") is not None
 
-    publication_ready = bool(
-        all_success
-        and required_threads_present
-        and numa_ready
-        and perf_ready
-        and args.repeats >= 10
-        and args.warmups >= 2
-    )
+    hardware_measurement_ready = bool(all_success and required_threads_present and numa_ready and perf_ready and args.repeats >= 10 and args.warmups >= 2)
 
     report = {
         "schema_version": 1,
         "artifact_type": "velographx-controlled-hardware-campaign",
-        "research_claim": publication_ready,
-        "publication_ready": publication_ready,
+        "research_claim": False,
+        "publication_ready": False,
+        "hardware_measurement_ready": hardware_measurement_ready,
         "claim_gate": {
             "all_measurements_succeeded": all_success,
             "threads_1_2_4_8_16_32_available": required_threads_present,
@@ -176,40 +160,22 @@ def main():
             "minimum_warmups_met": args.warmups >= 2,
             "competitor_and_dataset_validation_required_separately": True,
             "allow_publication_claims": False,
-            "note": "This runner alone never authorizes comparative publication claims; pinned datasets, correctness bundles, and same-hardware native competitors must also pass repository validators."
+            "note": "This artifact can establish hardware-measurement readiness only. Publication readiness requires pinned datasets, exact correctness, same-hardware native competitors, ablations, environment capture, and final repository validation."
         },
         "host": {
-            "platform": platform.platform(),
-            "machine": platform.machine(),
-            "cpu_count": cpu_count,
-            "numa_nodes": numa_nodes,
-            "taskset_available": shutil.which("taskset") is not None,
-            "numactl_available": shutil.which("numactl") is not None,
-            "perf_available": shutil.which("perf") is not None,
+            "platform": platform.platform(), "machine": platform.machine(), "cpu_count": cpu_count, "numa_nodes": numa_nodes,
+            "taskset_available": shutil.which("taskset") is not None, "numactl_available": shutil.which("numactl") is not None, "perf_available": shutil.which("perf") is not None,
         },
         "configuration": {
-            "requested_threads": threads,
-            "executed_threads": executable_threads,
-            "skipped_threads": skipped_threads,
-            "repeats": args.repeats,
-            "warmups": args.warmups,
-            "perf": args.perf,
-            "perf_events": args.perf_events if args.perf else None,
-            "numa": args.numa,
-            "command": command,
+            "requested_threads": threads, "executed_threads": executable_threads, "skipped_threads": skipped_threads,
+            "repeats": args.repeats, "warmups": args.warmups, "perf": args.perf,
+            "perf_events": args.perf_events if args.perf else None, "numa": args.numa, "command": command,
         },
         "cases": cases,
     }
 
     Path(args.output).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(json.dumps({
-        "output": args.output,
-        "publication_ready": publication_ready,
-        "executed_threads": executable_threads,
-        "skipped_threads": skipped_threads,
-        "numa_nodes": numa_nodes,
-        "cases": len(cases),
-    }, sort_keys=True))
+    print(json.dumps({"output": args.output, "hardware_measurement_ready": hardware_measurement_ready, "publication_ready": False, "research_claim": False, "executed_threads": executable_threads, "skipped_threads": skipped_threads, "numa_nodes": numa_nodes, "cases": len(cases)}, sort_keys=True))
     return 0 if all_success else 1
 
 

--- a/tools/run_controlled_hardware_campaign.py
+++ b/tools/run_controlled_hardware_campaign.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import platform
+import shutil
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_THREADS = [1, 2, 4, 8, 16, 32]
+DEFAULT_PERF_EVENTS = "cycles,instructions,branches,branch-misses,cache-references,cache-misses"
+
+
+def run(cmd, timeout):
+    completed = subprocess.run(cmd, text=True, capture_output=True, timeout=timeout, check=False)
+    return {
+        "argv": cmd,
+        "returncode": completed.returncode,
+        "stdout": completed.stdout.strip(),
+        "stderr": completed.stderr.strip(),
+    }
+
+
+def detect_numa_nodes():
+    if not shutil.which("numactl"):
+        return []
+    probe = subprocess.run(["numactl", "--hardware"], text=True, capture_output=True, check=False)
+    if probe.returncode != 0:
+        return []
+    nodes = []
+    for line in probe.stdout.splitlines():
+        if line.startswith("available:") and "nodes" in line:
+            try:
+                count = int(line.split()[1])
+                nodes = list(range(count))
+            except (ValueError, IndexError):
+                pass
+    return nodes
+
+
+def parse_driver_report(result):
+    if result["returncode"] != 0:
+        return None
+    lines = [line for line in result["stdout"].splitlines() if line.strip()]
+    if not lines:
+        return None
+    try:
+        return json.loads(lines[-1])
+    except json.JSONDecodeError:
+        return None
+
+
+def summarize(samples):
+    values = [sample["wall_seconds"] for sample in samples if sample.get("returncode") == 0]
+    if not values:
+        return {"n": 0}
+    ordered = sorted(values)
+    p95_index = min(len(ordered) - 1, max(0, int(round(0.95 * (len(ordered) - 1)))))
+    return {
+        "n": len(values),
+        "median_wall_seconds": statistics.median(values),
+        "p95_wall_seconds": ordered[p95_index],
+        "min_wall_seconds": min(values),
+        "max_wall_seconds": max(values),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Execute VeloGraphX publication-grade controlled-hardware campaign cases.")
+    parser.add_argument("--output", default="controlled-hardware-results.json")
+    parser.add_argument("--repeats", type=int, default=10)
+    parser.add_argument("--warmups", type=int, default=2)
+    parser.add_argument("--threads", default=",".join(str(x) for x in DEFAULT_THREADS))
+    parser.add_argument("--perf", action="store_true")
+    parser.add_argument("--perf-events", default=DEFAULT_PERF_EVENTS)
+    parser.add_argument("--numa", action="store_true")
+    parser.add_argument("--timeout-seconds", type=float, default=600)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    if args.repeats < 1 or args.warmups < 0:
+        raise ValueError("repeats must be >=1 and warmups must be >=0")
+    command = list(args.command)
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        raise ValueError("benchmark command is required after --")
+
+    threads = sorted(set(int(x) for x in args.threads.split(",") if x.strip()))
+    cpu_count = os.cpu_count() or 1
+    executable_threads = [t for t in threads if t <= cpu_count]
+    skipped_threads = [t for t in threads if t > cpu_count]
+    numa_nodes = detect_numa_nodes()
+
+    driver = str(Path(__file__).with_name("hardware_campaign_driver.py"))
+    cases = []
+
+    def execute_case(kind, thread_count, numa_policy="none", numa_node=0, perf=False):
+        base = [sys.executable, driver, "--threads", str(thread_count), "--numa-policy", numa_policy]
+        if numa_policy == "local":
+            base += ["--numa-node", str(numa_node)]
+        if perf:
+            base += ["--perf", "--perf-events", args.perf_events]
+        base += ["--timeout-seconds", str(args.timeout_seconds), "--"] + command
+
+        for _ in range(args.warmups):
+            warm = run(base, args.timeout_seconds + 30)
+            if warm["returncode"] != 0:
+                break
+
+        samples = []
+        for _ in range(args.repeats):
+            result = run(base, args.timeout_seconds + 30)
+            report = parse_driver_report(result)
+            samples.append(report or {
+                "returncode": result["returncode"],
+                "wall_seconds": None,
+                "stdout": result["stdout"],
+                "stderr": result["stderr"],
+            })
+
+        cases.append({
+            "kind": kind,
+            "threads": thread_count,
+            "numa_policy": numa_policy,
+            "numa_node": numa_node if numa_policy == "local" else None,
+            "perf": perf,
+            "summary": summarize(samples),
+            "samples": samples,
+        })
+
+    for t in executable_threads:
+        execute_case("thread_scaling", t)
+
+    if args.perf:
+        perf_thread = max(executable_threads) if executable_threads else 1
+        execute_case("hardware_counters", perf_thread, perf=True)
+
+    if args.numa:
+        if len(numa_nodes) >= 2:
+            peak_threads = max(executable_threads) if executable_threads else 1
+            execute_case("numa_local", peak_threads, numa_policy="local", numa_node=numa_nodes[0])
+            execute_case("numa_local", peak_threads, numa_policy="local", numa_node=numa_nodes[1])
+            execute_case("numa_interleave", peak_threads, numa_policy="interleave")
+        else:
+            cases.append({"kind": "numa", "skipped": True, "reason": "fewer than two genuine NUMA nodes detected"})
+
+    all_measured = [case for case in cases if not case.get("skipped")]
+    all_success = all(case.get("summary", {}).get("n", 0) == args.repeats for case in all_measured)
+    required_threads_present = all(t in executable_threads for t in DEFAULT_THREADS)
+    numa_ready = (not args.numa) or len(numa_nodes) >= 2
+    perf_ready = (not args.perf) or shutil.which("perf") is not None
+
+    publication_ready = bool(
+        all_success
+        and required_threads_present
+        and numa_ready
+        and perf_ready
+        and args.repeats >= 10
+        and args.warmups >= 2
+    )
+
+    report = {
+        "schema_version": 1,
+        "artifact_type": "velographx-controlled-hardware-campaign",
+        "research_claim": publication_ready,
+        "publication_ready": publication_ready,
+        "claim_gate": {
+            "all_measurements_succeeded": all_success,
+            "threads_1_2_4_8_16_32_available": required_threads_present,
+            "genuine_numa_requirement_met": numa_ready,
+            "perf_requirement_met": perf_ready,
+            "minimum_repeats_met": args.repeats >= 10,
+            "minimum_warmups_met": args.warmups >= 2,
+            "competitor_and_dataset_validation_required_separately": True,
+            "allow_publication_claims": False,
+            "note": "This runner alone never authorizes comparative publication claims; pinned datasets, correctness bundles, and same-hardware native competitors must also pass repository validators."
+        },
+        "host": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "cpu_count": cpu_count,
+            "numa_nodes": numa_nodes,
+            "taskset_available": shutil.which("taskset") is not None,
+            "numactl_available": shutil.which("numactl") is not None,
+            "perf_available": shutil.which("perf") is not None,
+        },
+        "configuration": {
+            "requested_threads": threads,
+            "executed_threads": executable_threads,
+            "skipped_threads": skipped_threads,
+            "repeats": args.repeats,
+            "warmups": args.warmups,
+            "perf": args.perf,
+            "perf_events": args.perf_events if args.perf else None,
+            "numa": args.numa,
+            "command": command,
+        },
+        "cases": cases,
+    }
+
+    Path(args.output).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "output": args.output,
+        "publication_ready": publication_ready,
+        "executed_threads": executable_threads,
+        "skipped_threads": skipped_threads,
+        "numa_nodes": numa_nodes,
+        "cases": len(cases),
+    }, sort_keys=True))
+    return 0 if all_success else 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
## Summary

Adds the missing top-level Phase B orchestrator for Issue #10 without fabricating dedicated-hardware results.

- executes repeated 1/2/4/8/16/32 thread-scaling cases where hardware supports them
- optionally collects Linux `perf` counters
- optionally executes genuine NUMA-local and interleave cases when at least two NUMA nodes are detected
- records raw per-sample driver output plus median/p95/min/max summaries
- records skipped thread counts and detected host capabilities
- preserves a conservative claim gate: the runner alone never authorizes publication claims
- documents the exact dedicated-hardware execution procedure and required companion evidence

This PR makes Phase B executable on suitable dedicated hardware. Issue #10 should remain open until real controlled-hardware measurements, pinned same-machine competitors, correctness validation, and final evidence bundles are produced and pass repository validators.

Refs #10