### PR TITLE
bench: add hosted native competitor build evidence

### DIFF
--- a/.github/workflows/hosted-native-competitors.yml
+++ b/.github/workflows/hosted-native-competitors.yml
@@ -5,12 +5,13 @@ on:
     paths:
       - '.github/workflows/hosted-native-competitors.yml'
       - 'docs/hosted-native-competitors.md'
+      - 'tools/run_hosted_native_measurements.py'
   workflow_dispatch:
 
 jobs:
   native-build-smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       GRAPHBLAS_TAG: v10.3.2
       LAGRAPH_TAG: v1.2.2
@@ -56,6 +57,12 @@ jobs:
             echo "GAPBS $GAPBS_TAG $(git -C external/gapbs rev-parse HEAD)"
           } | tee artifacts/native/native-pins.txt
 
+      - name: Build VeloGraphX benchmark
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DVELOGRAPHX_BUILD_TESTS=ON -DVELOGRAPHX_BUILD_BENCHMARKS=ON
+          cmake --build build --parallel 2
+          ctest --test-dir build --output-on-failure
+
       - name: Build SuiteSparse GraphBLAS
         run: |
           cmake -S external/GraphBLAS -B external/GraphBLAS/build \
@@ -72,11 +79,22 @@ jobs:
             -DCMAKE_INSTALL_PREFIX="$PWD/external/install"
           cmake --build external/LAGraph/build --parallel 2
           cmake --install external/LAGraph/build
+          test -x external/LAGraph/build/src/benchmark/bfs_demo
 
       - name: Build GAP Benchmark Suite BFS
         run: |
           make -C external/gapbs bfs -j2
           test -x external/gapbs/bfs
+
+      - name: Execute same-runner hosted measurements
+        env:
+          LD_LIBRARY_PATH: ${{ github.workspace }}/external/install/lib:${{ github.workspace }}/external/install/lib64
+        run: |
+          python tools/run_hosted_native_measurements.py \
+            --output-dir artifacts/native \
+            --gap-bfs external/gapbs/bfs \
+            --lagraph-bfs-demo external/LAGraph/build/src/benchmark/bfs_demo \
+            --velographx-benchmark build/velographx_benchmark
 
       - name: Record native build evidence
         run: |
@@ -98,15 +116,30 @@ jobs:
               "builds": {
                   "graphblas_library_present": any(pathlib.Path("external/install").rglob("libgraphblas*")),
                   "lagraph_library_present": any(pathlib.Path("external/install").rglob("liblagraph*")),
+                  "lagraph_bfs_demo_present": pathlib.Path("external/LAGraph/build/src/benchmark/bfs_demo").is_file(),
                   "gap_bfs_present": pathlib.Path("external/gapbs/bfs").is_file(),
               },
               "claim_gate": {
                   "publication_ready": False,
-                  "allowed_claim": "Hosted-CI native competitor build/readiness evidence only; no publication-grade timing claim."
+                  "allowed_claim": "Hosted-CI native build/readiness and same-runner engineering timing only; no publication-grade timing claim."
               }
           }
           assert all(payload["builds"].values())
           pathlib.Path("artifacts/native/native-build.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+          PY
+
+      - name: Validate hosted claim gate
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          r = json.loads(Path('artifacts/native/hosted-native-measurements.json').read_text())
+          assert r['research_claim'] is False
+          assert r['publication_grade'] is False
+          assert r['normalized_cross_engine_claim'] is False
+          assert r['claim_gate']['publication_ready'] is False
+          assert [x['threads'] for x in r['gap_bfs']] == [1,2,4]
+          assert [x['threads'] for x in r['lagraph_bfs']] == [1,2,4]
           PY
 
       - name: Upload hosted native evidence

--- a/.github/workflows/hosted-native-competitors.yml
+++ b/.github/workflows/hosted-native-competitors.yml
@@ -71,6 +71,19 @@ jobs:
           cmake --build external/GraphBLAS/build --parallel 2
           cmake --install external/GraphBLAS/build
 
+      - name: Enable LAGraph benchmark self-check
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          p = Path('external/LAGraph/src/benchmark/LAGraph_demo.h')
+          text = p.read_text()
+          old = '#define LG_CHECK_RESULT 0'
+          new = '#define LG_CHECK_RESULT 1'
+          if old not in text:
+              raise SystemExit('expected LAGraph self-check macro not found')
+          p.write_text(text.replace(old, new, 1))
+          PY
+
       - name: Build LAGraph against pinned GraphBLAS
         run: |
           cmake -S external/LAGraph -B external/LAGraph/build \
@@ -138,6 +151,10 @@ jobs:
           assert r['publication_grade'] is False
           assert r['normalized_cross_engine_claim'] is False
           assert r['claim_gate']['publication_ready'] is False
+          assert r['correctness_gate']['passed'] is True
+          assert r['correctness_gate']['gap_all_trials_verified'] is True
+          assert r['correctness_gate']['lagraph_self_check_present_all_threads'] is True
+          assert r['correctness_gate']['same_source_cross_engine_proven'] is False
           assert [x['threads'] for x in r['gap_bfs']] == [1,2,4]
           assert [x['threads'] for x in r['lagraph_bfs']] == [1,2,4]
           PY

--- a/.github/workflows/hosted-native-competitors.yml
+++ b/.github/workflows/hosted-native-competitors.yml
@@ -1,0 +1,117 @@
+name: Hosted Native Competitor Evidence
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/hosted-native-competitors.yml'
+      - 'docs/hosted-native-competitors.md'
+  workflow_dispatch:
+
+jobs:
+  native-build-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      GRAPHBLAS_TAG: v10.3.2
+      LAGRAPH_TAG: v1.2.2
+      GAPBS_TAG: v1.5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build libomp-dev
+
+      - name: Capture hosted runner capacity
+        run: |
+          mkdir -p artifacts/native
+          python - <<'PY'
+          import json, os, platform, shutil, subprocess
+          def cmd(argv):
+              p = subprocess.run(argv, text=True, capture_output=True, check=False)
+              return {"returncode": p.returncode, "stdout": p.stdout.strip(), "stderr": p.stderr.strip()}
+          payload = {
+              "research_claim": False,
+              "publication_grade": False,
+              "cpu_count": os.cpu_count(),
+              "platform": platform.platform(),
+              "machine": platform.machine(),
+              "taskset": shutil.which("taskset"),
+              "numactl": shutil.which("numactl"),
+              "perf": shutil.which("perf"),
+              "lscpu": cmd(["lscpu"]),
+          }
+          open("artifacts/native/host-capacity.json", "w").write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+          PY
+
+      - name: Clone immutable native competitor tags
+        run: |
+          git clone --depth 1 --branch "$GRAPHBLAS_TAG" https://github.com/DrTimothyAldenDavis/GraphBLAS.git external/GraphBLAS
+          git clone --depth 1 --branch "$LAGRAPH_TAG" https://github.com/GraphBLAS/LAGraph.git external/LAGraph
+          git clone --depth 1 --branch "$GAPBS_TAG" https://github.com/sbeamer/gapbs.git external/gapbs
+          {
+            echo "GraphBLAS $GRAPHBLAS_TAG $(git -C external/GraphBLAS rev-parse HEAD)"
+            echo "LAGraph $LAGRAPH_TAG $(git -C external/LAGraph rev-parse HEAD)"
+            echo "GAPBS $GAPBS_TAG $(git -C external/gapbs rev-parse HEAD)"
+          } | tee artifacts/native/native-pins.txt
+
+      - name: Build SuiteSparse GraphBLAS
+        run: |
+          cmake -S external/GraphBLAS -B external/GraphBLAS/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/external/install"
+          cmake --build external/GraphBLAS/build --parallel 2
+          cmake --install external/GraphBLAS/build
+
+      - name: Build LAGraph against pinned GraphBLAS
+        run: |
+          cmake -S external/LAGraph -B external/LAGraph/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$PWD/external/install" \
+            -DCMAKE_INSTALL_PREFIX="$PWD/external/install"
+          cmake --build external/LAGraph/build --parallel 2
+          cmake --install external/LAGraph/build
+
+      - name: Build GAP Benchmark Suite BFS
+        run: |
+          make -C external/gapbs bfs -j2
+          test -x external/gapbs/bfs
+
+      - name: Record native build evidence
+        run: |
+          python - <<'PY'
+          import json, os, pathlib, subprocess
+          def rev(path):
+              return subprocess.check_output(["git", "-C", path, "rev-parse", "HEAD"], text=True).strip()
+          payload = {
+              "schema_version": 1,
+              "artifact_type": "velographx-hosted-native-competitor-build",
+              "research_claim": False,
+              "publication_grade": False,
+              "same_runner": True,
+              "pins": {
+                  "SuiteSparse:GraphBLAS": {"tag": os.environ["GRAPHBLAS_TAG"], "commit": rev("external/GraphBLAS")},
+                  "LAGraph": {"tag": os.environ["LAGRAPH_TAG"], "commit": rev("external/LAGraph")},
+                  "GAP Benchmark Suite": {"tag": os.environ["GAPBS_TAG"], "commit": rev("external/gapbs")},
+              },
+              "builds": {
+                  "graphblas_library_present": any(pathlib.Path("external/install").rglob("libgraphblas*")),
+                  "lagraph_library_present": any(pathlib.Path("external/install").rglob("liblagraph*")),
+                  "gap_bfs_present": pathlib.Path("external/gapbs/bfs").is_file(),
+              },
+              "claim_gate": {
+                  "publication_ready": False,
+                  "allowed_claim": "Hosted-CI native competitor build/readiness evidence only; no publication-grade timing claim."
+              }
+          }
+          assert all(payload["builds"].values())
+          pathlib.Path("artifacts/native/native-build.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+          PY
+
+      - name: Upload hosted native evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: velographx-hosted-native-competitor-evidence
+          path: artifacts/native
+          retention-days: 30

--- a/docs/hosted-native-competitors.md
+++ b/docs/hosted-native-competitors.md
@@ -1,0 +1,15 @@
+# Hosted native competitor evidence
+
+This workflow extends the hosted engineering baseline by verifying that pinned native competitors can be built on the same GitHub-hosted Linux runner used for VeloGraphX engineering evidence.
+
+Pinned identities:
+
+- SuiteSparse:GraphBLAS `v10.3.2`
+- LAGraph `v1.2.2`
+- GAP Benchmark Suite `v1.5`
+
+The workflow captures runner capacity, immutable resolved commit SHAs, and release builds of GraphBLAS, LAGraph, and GAP BFS. It deliberately does **not** convert successful hosted builds into publication-grade timing claims.
+
+The next step after this build-readiness gate is to add normalized BFS runner binaries that satisfy the existing `tools/native_competitors/*_wrapper.py` contract, then execute same-runner correctness-checked timing through `tools/competitor_benchmark.py`.
+
+Hosted runner results remain `research_claim: false` and `publication_grade: false`. Dedicated hardware is still required for Issue #10 publication-grade scaling, NUMA, counter, and native competitor claims.

--- a/tools/run_hosted_native_measurements.py
+++ b/tools/run_hosted_native_measurements.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+import statistics
+import subprocess
+from pathlib import Path
+
+THREADS = (1, 2, 4)
+
+
+def run(argv, *, env=None, stdin=None, allow_failure=False):
+    proc = subprocess.run(argv, text=True, input=stdin, capture_output=True, env=env, check=False)
+    if proc.returncode != 0 and not allow_failure:
+        raise RuntimeError(f"command failed ({proc.returncode}): {' '.join(map(str, argv))}\n{proc.stderr or proc.stdout}")
+    return {"argv": [str(x) for x in argv], "returncode": proc.returncode,
+            "stdout": proc.stdout, "stderr": proc.stderr}
+
+
+def generate_graph(outdir: Path):
+    n = 4096
+    edges = set()
+    for u in range(n):
+        for delta in (1, 7, 31, 127):
+            v = (u + delta) % n
+            a, b = sorted((u, v))
+            if a != b:
+                edges.add((a, b))
+    ordered = sorted(edges)
+    el = outdir / "hosted-native.el"
+    el.write_text("".join(f"{u} {v}\n" for u, v in ordered))
+    mtx = outdir / "hosted-native.mtx"
+    # LAGraph expects MatrixMarket; symmetric storage describes an undirected graph.
+    with mtx.open("w") as f:
+        f.write("%%MatrixMarket matrix coordinate pattern symmetric\n")
+        f.write(f"{n} {n} {len(ordered)}\n")
+        for u, v in ordered:
+            f.write(f"{u+1} {v+1}\n")
+    return {"vertices": n, "undirected_edges": len(ordered), "edge_list": str(el), "matrix_market": str(mtx)}
+
+
+def gap_measurements(gap_bfs: Path, dataset: Path):
+    rows = []
+    trial_re = re.compile(r"Trial Time:\s*([0-9.eE+-]+)")
+    for t in THREADS:
+        env = os.environ.copy()
+        env["OMP_NUM_THREADS"] = str(t)
+        result = run([gap_bfs, "-sf", dataset, "-n", "5"], env=env)
+        combined = result["stdout"] + "\n" + result["stderr"]
+        samples = [float(x) for x in trial_re.findall(combined)]
+        rows.append({
+            "threads": t,
+            "returncode": result["returncode"],
+            "trial_seconds": samples,
+            "median_seconds": statistics.median(samples) if samples else None,
+            "verification_passed": "Verification: PASS" in combined,
+            "stdout_tail": result["stdout"][-4000:],
+            "stderr_tail": result["stderr"][-4000:],
+        })
+    return rows
+
+
+def lagraph_measurements(bfs_demo: Path, matrix_market: Path):
+    rows = []
+    avg_re = re.compile(r"Avg: BFS pushpull parent only, threads\s+\d+:\s+([0-9.eE+-]+) sec")
+    matrix_text = matrix_market.read_text()
+    for t in THREADS:
+        env = os.environ.copy()
+        env["OMP_NUM_THREADS"] = str(t)
+        env["OMP_THREAD_LIMIT"] = str(t)
+        result = run([bfs_demo, str(matrix_market)], env=env, stdin=matrix_text)
+        combined = result["stdout"] + "\n" + result["stderr"]
+        values = [float(x) for x in avg_re.findall(combined)]
+        rows.append({
+            "threads": t,
+            "returncode": result["returncode"],
+            "average_seconds": values[-1] if values else None,
+            "benchmark_self_check_present": "check:" in combined,
+            "stdout_tail": result["stdout"][-4000:],
+            "stderr_tail": result["stderr"][-4000:],
+        })
+    return rows
+
+
+def perf_attempt(velographx_bench: Path):
+    result = run([
+        "python3", "tools/hardware_campaign_driver.py", "--threads", "1", "--perf",
+        "--perf-events", "cycles,instructions,cache-misses,branches,branch-misses", "--", str(velographx_bench)
+    ], allow_failure=True)
+    payload = {"status": "unavailable-or-denied", "returncode": result["returncode"],
+               "stdout": result["stdout"], "stderr": result["stderr"]}
+    if result["returncode"] == 0:
+        try:
+            payload = {"status": "available", "result": json.loads(result["stdout"])}
+        except json.JSONDecodeError:
+            payload["status"] = "unexpected-output"
+    return payload
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--output-dir", type=Path, required=True)
+    p.add_argument("--gap-bfs", type=Path, required=True)
+    p.add_argument("--lagraph-bfs-demo", type=Path, required=True)
+    p.add_argument("--velographx-benchmark", type=Path, required=True)
+    args = p.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    graph = generate_graph(args.output_dir)
+    report = {
+        "schema_version": 1,
+        "artifact_type": "velographx-hosted-native-measurements",
+        "research_claim": False,
+        "publication_grade": False,
+        "normalized_cross_engine_claim": False,
+        "graph": graph,
+        "gap_bfs": gap_measurements(args.gap_bfs, Path(graph["edge_list"])),
+        "lagraph_bfs": lagraph_measurements(args.lagraph_bfs_demo, Path(graph["matrix_market"])),
+        "velographx_perf": perf_attempt(args.velographx_benchmark),
+        "claim_gate": {
+            "publication_ready": False,
+            "allowed_claim": "Hosted-CI same-runner engineering timing only. GAP and LAGraph upstream harness semantics are recorded separately; no normalized cross-engine speedup claim."
+        }
+    }
+    out = args.output_dir / "hosted-native-measurements.json"
+    out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(json.dumps({
+        "ok": True,
+        "gap_threads": [x["threads"] for x in report["gap_bfs"]],
+        "lagraph_threads": [x["threads"] for x in report["lagraph_bfs"]],
+        "perf_status": report["velographx_perf"]["status"]
+    }))
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_hosted_native_measurements.py
+++ b/tools/run_hosted_native_measurements.py
@@ -44,21 +44,27 @@ def generate_graph(outdir: Path):
 def gap_measurements(gap_bfs: Path, dataset: Path):
     rows = []
     trial_re = re.compile(r"Trial Time:\s*([0-9.eE+-]+)")
+    verification_re = re.compile(r"^Verification:\s*(PASS|FAIL)\s*$", re.MULTILINE)
     for t in THREADS:
         env = os.environ.copy()
         env["OMP_NUM_THREADS"] = str(t)
         result = run([gap_bfs, "-sf", dataset, "-r", str(SOURCE), "-n", "5", "-v"], env=env)
         combined = result["stdout"] + "\n" + result["stderr"]
         samples = [float(x) for x in trial_re.findall(combined)]
-        verification_count = combined.count("Verification: PASS")
+        verification_results = verification_re.findall(combined)
+        pass_count = sum(x == "PASS" for x in verification_results)
+        fail_count = sum(x == "FAIL" for x in verification_results)
+        verification_passed = bool(samples) and pass_count == len(samples) and fail_count == 0
         rows.append({
             "threads": t,
             "source": SOURCE,
             "returncode": result["returncode"],
             "trial_seconds": samples,
             "median_seconds": statistics.median(samples) if samples else None,
-            "verification_passed": verification_count == 5,
-            "verification_pass_count": verification_count,
+            "verification_passed": verification_passed,
+            "verification_pass_count": pass_count,
+            "verification_fail_count": fail_count,
+            "verification_result_count": len(verification_results),
             "stdout_tail": result["stdout"][-4000:],
             "stderr_tail": result["stderr"][-4000:],
         })
@@ -142,7 +148,20 @@ def main():
     out = args.output_dir / "hosted-native-measurements.json"
     out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
     if not correctness_gate:
-        raise RuntimeError("native competitor correctness gate failed")
+        diagnostics = {
+            "gap": [{
+                "threads": x["threads"],
+                "trials": len(x["trial_seconds"]),
+                "passes": x["verification_pass_count"],
+                "fails": x["verification_fail_count"],
+            } for x in gap],
+            "lagraph": [{
+                "threads": x["threads"],
+                "timing_present": x["average_seconds"] is not None,
+                "self_check_present": x["benchmark_self_check_present"],
+            } for x in lagraph],
+        }
+        raise RuntimeError(f"native competitor correctness gate failed: {json.dumps(diagnostics, sort_keys=True)}")
     print(json.dumps({
         "ok": True,
         "correctness_gate": correctness_gate,

--- a/tools/run_hosted_native_measurements.py
+++ b/tools/run_hosted_native_measurements.py
@@ -8,6 +8,7 @@ import subprocess
 from pathlib import Path
 
 THREADS = (1, 2, 4)
+SOURCE = 0
 
 
 def run(argv, *, env=None, stdin=None, allow_failure=False):
@@ -31,13 +32,13 @@ def generate_graph(outdir: Path):
     el = outdir / "hosted-native.el"
     el.write_text("".join(f"{u} {v}\n" for u, v in ordered))
     mtx = outdir / "hosted-native.mtx"
-    # LAGraph expects MatrixMarket; symmetric storage describes an undirected graph.
     with mtx.open("w") as f:
         f.write("%%MatrixMarket matrix coordinate pattern symmetric\n")
         f.write(f"{n} {n} {len(ordered)}\n")
         for u, v in ordered:
             f.write(f"{u+1} {v+1}\n")
-    return {"vertices": n, "undirected_edges": len(ordered), "edge_list": str(el), "matrix_market": str(mtx)}
+    return {"vertices": n, "undirected_edges": len(ordered), "edge_list": str(el),
+            "matrix_market": str(mtx), "source": SOURCE}
 
 
 def gap_measurements(gap_bfs: Path, dataset: Path):
@@ -46,15 +47,18 @@ def gap_measurements(gap_bfs: Path, dataset: Path):
     for t in THREADS:
         env = os.environ.copy()
         env["OMP_NUM_THREADS"] = str(t)
-        result = run([gap_bfs, "-sf", dataset, "-n", "5"], env=env)
+        result = run([gap_bfs, "-sf", dataset, "-r", str(SOURCE), "-n", "5", "-v"], env=env)
         combined = result["stdout"] + "\n" + result["stderr"]
         samples = [float(x) for x in trial_re.findall(combined)]
+        verification_count = combined.count("Verification: PASS")
         rows.append({
             "threads": t,
+            "source": SOURCE,
             "returncode": result["returncode"],
             "trial_seconds": samples,
             "median_seconds": statistics.median(samples) if samples else None,
-            "verification_passed": "Verification: PASS" in combined,
+            "verification_passed": verification_count == 5,
+            "verification_pass_count": verification_count,
             "stdout_tail": result["stdout"][-4000:],
             "stderr_tail": result["stderr"][-4000:],
         })
@@ -72,11 +76,14 @@ def lagraph_measurements(bfs_demo: Path, matrix_market: Path):
         result = run([bfs_demo, str(matrix_market)], env=env, stdin=matrix_text)
         combined = result["stdout"] + "\n" + result["stderr"]
         values = [float(x) for x in avg_re.findall(combined)]
+        check_match = re.search(r"\bn:\s*[0-9.eE+-]+\s+check:\s*([0-9.eE+-]+)\s+sec", combined)
         rows.append({
             "threads": t,
             "returncode": result["returncode"],
             "average_seconds": values[-1] if values else None,
-            "benchmark_self_check_present": "check:" in combined,
+            "benchmark_self_check_present": check_match is not None,
+            "self_check_seconds": float(check_match.group(1)) if check_match else None,
+            "source_semantics": "LAGraph upstream demo source set; correctness self-check enabled at build time",
             "stdout_tail": result["stdout"][-4000:],
             "stderr_tail": result["stderr"][-4000:],
         })
@@ -107,27 +114,40 @@ def main():
     args = p.parse_args()
     args.output_dir.mkdir(parents=True, exist_ok=True)
     graph = generate_graph(args.output_dir)
+    gap = gap_measurements(args.gap_bfs, Path(graph["edge_list"]))
+    lagraph = lagraph_measurements(args.lagraph_bfs_demo, Path(graph["matrix_market"]))
+    correctness_gate = all(x["verification_passed"] for x in gap) and all(
+        x["benchmark_self_check_present"] for x in lagraph)
     report = {
-        "schema_version": 1,
+        "schema_version": 2,
         "artifact_type": "velographx-hosted-native-measurements",
         "research_claim": False,
         "publication_grade": False,
         "normalized_cross_engine_claim": False,
         "graph": graph,
-        "gap_bfs": gap_measurements(args.gap_bfs, Path(graph["edge_list"])),
-        "lagraph_bfs": lagraph_measurements(args.lagraph_bfs_demo, Path(graph["matrix_market"])),
+        "gap_bfs": gap,
+        "lagraph_bfs": lagraph,
+        "correctness_gate": {
+            "passed": correctness_gate,
+            "gap_all_trials_verified": all(x["verification_passed"] for x in gap),
+            "lagraph_self_check_present_all_threads": all(x["benchmark_self_check_present"] for x in lagraph),
+            "same_source_cross_engine_proven": False
+        },
         "velographx_perf": perf_attempt(args.velographx_benchmark),
         "claim_gate": {
             "publication_ready": False,
-            "allowed_claim": "Hosted-CI same-runner engineering timing only. GAP and LAGraph upstream harness semantics are recorded separately; no normalized cross-engine speedup claim."
+            "allowed_claim": "Hosted-CI same-runner engineering timing with upstream correctness checks. Cross-engine source/output semantics are not yet fully normalized; no normalized speedup or publication-grade claim."
         }
     }
     out = args.output_dir / "hosted-native-measurements.json"
     out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    if not correctness_gate:
+        raise RuntimeError("native competitor correctness gate failed")
     print(json.dumps({
         "ok": True,
-        "gap_threads": [x["threads"] for x in report["gap_bfs"]],
-        "lagraph_threads": [x["threads"] for x in report["lagraph_bfs"]],
+        "correctness_gate": correctness_gate,
+        "gap_threads": [x["threads"] for x in gap],
+        "lagraph_threads": [x["threads"] for x in lagraph],
         "perf_status": report["velographx_perf"]["status"]
     }))
 


### PR DESCRIPTION
## Summary

Adds a hosted-CI native competitor build/readiness gate for the subset of Issue #10 that can be exercised on current GitHub-hosted capacity.

- pins SuiteSparse:GraphBLAS v10.3.2
- pins LAGraph v1.2.2
- pins GAP Benchmark Suite v1.5
- resolves and records immutable commit SHAs at runtime
- builds GraphBLAS and LAGraph in Release mode on the same hosted Linux runner
- builds GAP BFS on the same runner
- captures runner CPU/platform/tool capacity
- uploads machine-readable build evidence
- keeps `research_claim: false`, `publication_grade: false`, and the publication gate closed

This is intentionally a build/readiness layer. Once CI confirms the pinned native stacks build reliably on current capacity, the next increment is normalized correctness-checked same-runner BFS timing through the existing external competitor contract.

Refs #10