### PR TITLE
Strengthen benchmark methodology from Gunrock feedback

### DIFF
--- a/.github/workflows/owens-benchmark-contract.yml
+++ b/.github/workflows/owens-benchmark-contract.yml
@@ -21,11 +21,15 @@ jobs:
           lscpu | tee artifacts/lscpu.txt
 
       - name: Prepare roadNet-CA with provenance checks
+        shell: bash
         run: |
+          set -o pipefail
           python3 scripts/prepare_publication_datasets.py roadnet-ca --output-dir data | tee artifacts/roadNet-CA.prepare.json
 
       - name: Prepare deterministic Kronecker smoke workload
+        shell: bash
         run: |
+          set -o pipefail
           python3 scripts/prepare_publication_datasets.py kronecker --output-dir data --scale 16 --edgefactor 16 --seed 1 | tee artifacts/kron-scale16.prepare.json
 
       - name: Build public benchmark
@@ -34,13 +38,17 @@ jobs:
           cmake --build build --target velographx_public_dataset_benchmark -j2
 
       - name: Run road-network benchmark
+        shell: bash
         run: |
+          set -o pipefail
           /usr/bin/time -v -o artifacts/roadNet-CA.time.txt \
             ./build/velographx_public_dataset_benchmark data/roadNet-CA.edges 0 \
             | tee artifacts/roadNet-CA.csv
 
       - name: Run Kronecker benchmark
+        shell: bash
         run: |
+          set -o pipefail
           /usr/bin/time -v -o artifacts/kron-scale16.time.txt \
             ./build/velographx_public_dataset_benchmark data/kron-scale16-ef16-seed1.edges 0 \
             | tee artifacts/kron-scale16.csv
@@ -49,6 +57,8 @@ jobs:
         run: |
           grep -q 'bfs_end_to_end_us' artifacts/roadNet-CA.csv
           grep -q 'triangle_end_to_end_us' artifacts/kron-scale16.csv
+          test -s artifacts/roadNet-CA.prepare.json
+          test -s artifacts/kron-scale16.prepare.json
           test -s data/roadNet-CA.metadata.json
           test -s data/kron-scale16-ef16-seed1.metadata.json
 

--- a/.github/workflows/owens-benchmark-contract.yml
+++ b/.github/workflows/owens-benchmark-contract.yml
@@ -1,0 +1,61 @@
+name: Owens Benchmark Contract
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  representative-families:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Capture runner memory
+        run: |
+          mkdir -p artifacts
+          free -h | tee artifacts/memory.txt
+          lscpu | tee artifacts/lscpu.txt
+
+      - name: Prepare roadNet-CA with provenance checks
+        run: |
+          python3 scripts/prepare_publication_datasets.py roadnet-ca --output-dir data | tee artifacts/roadNet-CA.prepare.json
+
+      - name: Prepare deterministic Kronecker smoke workload
+        run: |
+          python3 scripts/prepare_publication_datasets.py kronecker --output-dir data --scale 16 --edgefactor 16 --seed 1 | tee artifacts/kron-scale16.prepare.json
+
+      - name: Build public benchmark
+        run: |
+          cmake -S . -B build -DVELOGRAPHX_BUILD_TESTS=OFF -DVELOGRAPHX_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --target velographx_public_dataset_benchmark -j2
+
+      - name: Run road-network benchmark
+        run: |
+          /usr/bin/time -v -o artifacts/roadNet-CA.time.txt \
+            ./build/velographx_public_dataset_benchmark data/roadNet-CA.edges 0 \
+            | tee artifacts/roadNet-CA.csv
+
+      - name: Run Kronecker benchmark
+        run: |
+          /usr/bin/time -v -o artifacts/kron-scale16.time.txt \
+            ./build/velographx_public_dataset_benchmark data/kron-scale16-ef16-seed1.edges 0 \
+            | tee artifacts/kron-scale16.csv
+
+      - name: Verify end-to-end timing columns
+        run: |
+          grep -q 'bfs_end_to_end_us' artifacts/roadNet-CA.csv
+          grep -q 'triangle_end_to_end_us' artifacts/kron-scale16.csv
+          test -s data/roadNet-CA.metadata.json
+          test -s data/kron-scale16-ef16-seed1.metadata.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: owens-benchmark-contract
+          path: |
+            artifacts/
+            data/*.metadata.json
+          retention-days: 30

--- a/benchmarks/public_dataset_benchmark.cpp
+++ b/benchmarks/public_dataset_benchmark.cpp
@@ -23,7 +23,9 @@ int main(int argc, char** argv) {
       : 0;
   using clock = std::chrono::steady_clock;
 
-  const auto load_begin = clock::now();
+  // End-to-end timing begins when a standard, non-preprocessed edge list is
+  // handed to VeloGraphX. Kernel-only timing begins after graph construction.
+  const auto input_begin = clock::now();
   const auto graph = velographx::load_edge_list(dataset, false);
   const auto load_end = clock::now();
 
@@ -52,13 +54,28 @@ int main(int argc, char** argv) {
   const auto us = [](auto begin, auto end) {
     return std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
   };
+  const auto load_us = us(input_begin, load_end);
+
+  // Each end-to-end value is deliberately expressed as load/conversion plus
+  // that kernel's own execution time. This prevents a fast internal layout
+  // conversion from being hidden when comparing systems, while preserving a
+  // separate steady-state number for kernel-focused analysis.
+  const auto bfs_us = us(bfs_begin, bfs_end);
+  const auto components_us = us(cc_begin, cc_end);
+  const auto triangle_us = us(triangle_begin, triangle_end);
+  const auto pagerank_us = us(pagerank_begin, pagerank_end);
 
   std::cout
-      << "dataset,source,vertices,edge_entries,load_us,bfs_us,reachable_vertices,components_us,component_count,triangle_us,triangles,pagerank_us,pagerank_sum\n"
-      << dataset.string() << ',' << source << ',' << graph.vertex_count() << ',' << graph.edge_entry_count() << ','
-      << us(load_begin, load_end) << ',' << us(bfs_begin, bfs_end) << ',' << reachable << ','
-      << us(cc_begin, cc_end) << ',' << component_count << ','
-      << us(triangle_begin, triangle_end) << ',' << triangles << ','
-      << us(pagerank_begin, pagerank_end) << ',' << rank_sum << '\n';
+      << "dataset,source,input_contract,vertices,edge_entries,load_us,"
+         "bfs_us,bfs_end_to_end_us,reachable_vertices,"
+         "components_us,components_end_to_end_us,component_count,"
+         "triangle_us,triangle_end_to_end_us,triangles,"
+         "pagerank_us,pagerank_end_to_end_us,pagerank_sum\n"
+      << dataset.string() << ',' << source << ",edge-list," << graph.vertex_count() << ','
+      << graph.edge_entry_count() << ',' << load_us << ','
+      << bfs_us << ',' << (load_us + bfs_us) << ',' << reachable << ','
+      << components_us << ',' << (load_us + components_us) << ',' << component_count << ','
+      << triangle_us << ',' << (load_us + triangle_us) << ',' << triangles << ','
+      << pagerank_us << ',' << (load_us + pagerank_us) << ',' << rank_sum << '\n';
   return 0;
 }

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,3 +1,33 @@
 # Datasets
 
 Do not commit large third-party datasets to the repository. Benchmark scripts should download or generate datasets reproducibly and record licenses, hashes, seeds and preprocessing parameters.
+
+The publication benchmark contract is [`publication-benchmark-contract.json`](publication-benchmark-contract.json). It prevents dataset selection from drifting toward only favorable VeloGraphX workloads.
+
+## Required graph families
+
+A publication-level campaign must cover all of the following families:
+
+| Family | Canonical examples | Purpose |
+| --- | --- | --- |
+| Scale-free web | `web-Google` | Skewed web topology used broadly in graph-systems evaluation |
+| Scale-free social/community | `soc-Epinions1`, `com-LiveJournal`, `com-Orkut` | Multiple skewed real-world graph scales |
+| Road network | `roadNet-CA` | Low-degree, high-diameter counterpoint to scale-free graphs |
+| Synthetic Kronecker/R-MAT | Graph500-style generator | Controlled scalability and memory-capacity study |
+
+The canonical road workload is SNAP `roadNet-CA`: 1,965,206 vertices and 2,766,607 undirected edges in the source dataset. Downloaded bytes must be checksum-pinned by the benchmark campaign before results are accepted.
+
+## Synthetic graph parameters
+
+The default Kronecker/R-MAT contract uses:
+
+- `A=0.57`, `B=0.19`, `C=0.19`, `D=0.05`
+- edge factor `16`
+- scales `16, 18, 20, 22, 24, 26`
+- a fixed seed recorded in every artifact
+
+A campaign may use additional scales, but it must report the exact generator implementation, scale, edge factor, initiator probabilities and seed. Generated graphs are supplementary scalability workloads, not replacements for real public datasets.
+
+## Memory-limit campaign
+
+On dedicated benchmark hardware, attempt successively larger configured graphs and report the largest graph that completes without swapping or OOM. Retain machine RAM, NUMA topology, peak RSS and the next attempted scale when available. Out-of-memory/external-memory experiments must be labelled separately from the in-memory campaign.

--- a/datasets/publication-benchmark-contract.json
+++ b/datasets/publication-benchmark-contract.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "purpose": "Publication benchmark contract derived from external feedback on dataset representativeness, scalability and timing transparency.",
+  "dataset_families": [
+    {
+      "family": "scale-free-web",
+      "required": true,
+      "examples": ["web-Google"],
+      "rationale": "Common graph-systems workload with skewed degree distribution."
+    },
+    {
+      "family": "scale-free-social",
+      "required": true,
+      "examples": ["soc-Epinions1", "com-LiveJournal", "com-Orkut"],
+      "rationale": "Adds skewed social/community structure at multiple scales."
+    },
+    {
+      "family": "road-network",
+      "required": true,
+      "examples": ["roadNet-CA"],
+      "reference_url": "https://snap.stanford.edu/data/roadNet-CA.html",
+      "expected_vertices": 1965206,
+      "expected_undirected_edges": 2766607,
+      "rationale": "Low-degree, high-diameter graph family that counterbalances scale-free workloads."
+    },
+    {
+      "family": "kronecker-scalability",
+      "required": true,
+      "generator": "Graph500-style Kronecker/R-MAT",
+      "parameters": {
+        "A": 0.57,
+        "B": 0.19,
+        "C": 0.19,
+        "D": 0.05,
+        "edgefactor": 16,
+        "scales": [16, 18, 20, 22, 24, 26],
+        "seed_policy": "fixed and recorded per run"
+      },
+      "rationale": "Controlled strong-scaling and memory-capacity study with fully published generation parameters."
+    }
+  ],
+  "largest_practical_in_memory": {
+    "required": true,
+    "selection_rule": "On each benchmark machine, run the largest configured graph that completes without swapping or OOM and record peak RSS, RAM, NUMA topology and the next attempted scale when available.",
+    "out_of_memory_scope": "If larger-than-memory experiments are attempted, label them separately; never mix them with in-memory results."
+  },
+  "timing_contract": {
+    "standard_input_boundary": "Timing begins when a non-system-specific standard graph representation (edge list, COO or CSR) is available in memory or handed to the process.",
+    "end_to_end_includes": [
+      "graph ingestion",
+      "representation conversion",
+      "preprocessing/index construction",
+      "initial algorithm state construction when required",
+      "update application",
+      "incremental repair or recomputation",
+      "required synchronization"
+    ],
+    "validation": "Correctness/checksum validation is reported separately from performance timing unless a benchmark explicitly defines it as part of answer-ready latency.",
+    "steady_state": "Kernel-only or steady-state timings may also be reported, but must be labelled separately and may not replace end-to-end results."
+  },
+  "external_comparison_rule": "The same input boundary and inclusion/exclusion rules apply to VeloGraphX and every external baseline. Any unavoidable mismatch must be disclosed adjacent to the result.",
+  "artifact_requirements": [
+    "dataset identity and checksum",
+    "generator parameters and seed for synthetic graphs",
+    "software revisions",
+    "compiler and flags",
+    "CPU/RAM/NUMA topology",
+    "thread count and affinity",
+    "timing boundary metadata",
+    "peak memory where available",
+    "exactness/checksum result"
+  ]
+}

--- a/docs/benchmark-methodology.md
+++ b/docs/benchmark-methodology.md
@@ -4,17 +4,75 @@
 
 VeloGraphX does not publish performance claims without reproducible measurements. Benchmarks must report software versions, compiler and flags, CPU model, RAM, NUMA topology, thread count, dataset preparation, warmup, repetitions and whether loading/preprocessing time is included.
 
+The publication-level dataset and timing contract is machine-readable in [`datasets/publication-benchmark-contract.json`](../datasets/publication-benchmark-contract.json). Its requirements apply to VeloGraphX and to external systems used for direct comparison.
+
+## Dataset selection
+
+Dataset choice must be defensible independently of observed VeloGraphX performance. The primary suite therefore spans structurally different graph families rather than only workloads that are favorable to localized incremental repair.
+
+Required publication coverage is:
+
+- **Scale-free web graphs**, with `web-Google` as a canonical example.
+- **Scale-free social/community graphs**, including at least one of `soc-Epinions1`, `com-LiveJournal` or `com-Orkut` at an appropriate scale.
+- **Road networks**, with SNAP `roadNet-CA` as the canonical initial workload. Road graphs provide a deliberately different low-degree, high-diameter regime.
+- **Synthetic Kronecker/R-MAT graphs** for controlled scalability studies. Generator parameters, scale, edge factor and random seed must be retained with every result.
+
+A benchmark campaign may add datasets, but it must not silently remove a required family because its results are unfavorable. Dataset checksums or immutable derivation rules accompany accepted evidence.
+
+## Kronecker scalability contract
+
+The default controlled synthetic family follows the Graph500-style initiator `A=0.57`, `B=0.19`, `C=0.19`, `D=0.05` with edge factor `16`. Publication campaigns should attempt scales `16, 18, 20, 22, 24, 26` or a documented hardware-appropriate extension/reduction. Every run records the exact parameters and seed.
+
+Synthetic results are not substitutes for public real-world graphs. Their purpose is controlled scalability and memory-capacity analysis.
+
+## Largest-practical in-memory scale
+
+Each dedicated-hardware campaign must identify the largest configured graph that completes fully in memory without swapping or OOM. Report graph size, peak RSS, installed RAM, NUMA topology, thread count, and—where practical—the next attempted scale or the reason no larger attempt was made.
+
+If out-of-memory or external-memory behavior is studied, those results are a separate experiment class and must not be mixed with in-memory numbers.
+
+## Standard input boundary
+
+For end-to-end comparisons, timing begins when a non-system-specific graph representation is available to the system: a standard edge list, COO, CSR, or an equivalently neutral representation agreed for that campaign.
+
+A system may internally convert that representation into a proprietary layout, index, compressed form, snapshot representation, or auxiliary structure. That work is part of end-to-end cost unless the comparison explicitly measures a different contract.
+
+The default end-to-end envelope includes, as applicable:
+
+1. graph ingestion,
+2. representation conversion,
+3. preprocessing and index construction,
+4. initial algorithm-state construction,
+5. update application,
+6. incremental repair or full recomputation,
+7. synchronization required before the answer is usable.
+
+Correctness/checksum validation is normally kept outside the performance envelope and reported separately so validation overhead cannot distort system timing. If a benchmark definition requires validation inside answer-ready latency, that exception must be explicit and identical across systems.
+
+## End-to-end versus steady-state timing
+
+End-to-end and steady-state/kernel timing are different metrics and are never presented as interchangeable.
+
+- **End-to-end** starts at the standard input boundary and includes system-specific conversion/preprocessing.
+- **Steady-state/kernel** starts only after the system is fully initialized in its preferred internal representation.
+
+When both are useful, report both. A comparison must not use VeloGraphX end-to-end time against a competitor's preprocessed steady-state time, or vice versa.
+
+`velographx_public_dataset_benchmark` emits loading time, per-kernel steady-state time, and preprocessing-inclusive per-kernel end-to-end time in the same record.
+
 ## Static baseline
 
 Initial benchmarks cover graph construction, BFS, connected components, PageRank and triangle counting. Results should include vertices, directed edge entries, elapsed time and algorithm-specific work where available.
 
 ## Dynamic benchmark plan
 
-Future runs must separate graph mutation time from algorithm-state update time and total end-to-end latency. Update fractions should include approximately 0.0001%, 0.001%, 0.01%, 0.1%, 1%, 5% and 10% of edges. Each incremental result is compared with a fresh full recomputation.
+Dynamic runs must separate graph mutation time from algorithm-state update time and total answer-ready latency. Update fractions should include approximately 0.0001%, 0.001%, 0.01%, 0.1%, 1%, 5% and 10% of edges. Each incremental result is compared with a fresh full recomputation.
+
+For an external dynamic-system comparison, the report must state whether the timing envelope includes ingestion, representation conversion, preprocessing/index construction, initial analytics state, update application, repair/recomputation, synchronization and validation. Unavoidable semantic or timing mismatches are disclosed adjacent to the result rather than hidden in footnotes.
 
 ## Correctness
 
-Incremental outputs are invalid benchmark results unless they match full recomputation under exact or documented floating-point tolerance. Randomized differential tests precede large performance runs.
+Incremental outputs are invalid benchmark results unless they match full recomputation under exact or documented floating-point tolerance. Randomized differential tests precede large performance runs. Dataset identity, update-stream identity and exactness/checksum results are retained with benchmark artifacts.
 
 ## Repetitions
 
@@ -26,12 +84,16 @@ Where available report peak RSS, bytes per edge, cache misses, branch misses, cy
 
 ## Baselines
 
-Use semantically comparable versions of relevant libraries such as GAPBS, SuiteSparse:GraphBLAS/LAGraph, NetworKit, igraph, rustworkx and NetworkX when useful. Do not present an optimized C++ vs naive Python comparison as a systems breakthrough.
+Use semantically comparable versions of relevant libraries and research systems. Baseline choice should favor the strongest system appropriate to the workload semantics, not merely the easiest system to beat. Do not present an optimized C++ vs naive Python comparison as a systems breakthrough.
+
+For every direct baseline comparison, pin the external revision, preserve identical input/update streams where semantics permit, use the same thread/core contract and apply the same end-to-end timing boundary. Cases where an external baseline wins remain part of the evidence.
 
 ## Machine-readable results
 
-Benchmark programs should emit or be convertible to JSON/CSV with algorithm, mode, vertices, edges, update fraction, threads, elapsed time, affected vertices/edges, memory and machine metadata.
+Benchmark programs should emit or be convertible to JSON/CSV with algorithm, mode, input contract, vertices, edges, update fraction, threads, elapsed time, preprocessing/loading time, end-to-end time, affected vertices/edges, memory and machine metadata.
+
+Synthetic workloads additionally record all generation parameters and seeds.
 
 ## Unmeasured results
 
-Any report field not produced by an executed benchmark must say **Not measured yet.**
+Any report field not produced by an executed benchmark must say **Not measured yet.** A required publication experiment is not considered complete merely because its methodology has been specified.

--- a/docs/external-baseline-timing-contract.md
+++ b/docs/external-baseline-timing-contract.md
@@ -1,0 +1,53 @@
+# External Baseline Timing Contract
+
+Direct performance comparisons must use an explicit timing ledger. A result is not accepted merely because two systems ran the same algorithm: the measured envelope must also be comparable.
+
+## Required ledger
+
+Every external comparison records the following fields for **both** VeloGraphX and the baseline:
+
+| Stage | VeloGraphX | External baseline |
+| --- | --- | --- |
+| Standard input representation | required | required |
+| Graph ingestion included? | yes/no + time | yes/no + time |
+| Representation conversion included? | yes/no + time | yes/no + time |
+| Preprocessing/index construction included? | yes/no + time | yes/no + time |
+| Initial algorithm-state construction included? | yes/no + time | yes/no + time |
+| Update application included? | yes/no + time | yes/no + time |
+| Incremental repair/recomputation included? | yes/no + time | yes/no + time |
+| Required synchronization included? | yes/no + time | yes/no + time |
+| Validation/checksum included? | normally no | normally no |
+| Steady-state/kernel timing | separately labelled | separately labelled |
+| End-to-end timing | required for publication comparisons | required for publication comparisons |
+
+Blank cells are not allowed in an accepted result. If a stage is not applicable, record `N/A` and explain why.
+
+## Standard boundary
+
+The default end-to-end clock starts when a neutral, non-system-specific representation such as edge list, COO or CSR is handed to the system. System-specific conversion, compression, indexing, snapshot construction or auxiliary-state construction is therefore visible rather than silently amortized away.
+
+If a paper or artifact exposes only a preprocessed representation and no neutral-input path can be reproduced, the result must be labelled as a **steady-state/preprocessed comparison**, not an end-to-end comparison.
+
+## Symmetry rule
+
+A cost excluded for one system must also be excluded for the other system or the difference must be shown explicitly as a separate component. Examples:
+
+- Do not include VeloGraphX CSR construction while starting a baseline from an already-built proprietary index.
+- Do not include baseline update ingestion while timing only VeloGraphX repair.
+- Do not include checksum validation for only one system.
+- Do not compare one-thread VeloGraphX with unrestricted baseline parallelism unless the thread mismatch is the experiment being studied.
+
+## Reporting
+
+Accepted results should provide both:
+
+1. **end-to-end latency**, starting at the agreed standard input boundary; and
+2. **steady-state/kernel latency**, where useful for explaining internal algorithmic behavior.
+
+The two numbers answer different questions and must remain separately labelled in tables, CSV/JSON artifacts and README claims.
+
+## Existing evidence
+
+Historical hosted-CI evidence remains valid for the timing contract under which it was originally produced, but it must not be retroactively relabelled as preprocessing-inclusive if preprocessing was outside the measured envelope. New publication-grade campaigns follow this ledger.
+
+See also [`benchmark-methodology.md`](benchmark-methodology.md) and [`../datasets/publication-benchmark-contract.json`](../datasets/publication-benchmark-contract.json).

--- a/scripts/prepare_publication_datasets.py
+++ b/scripts/prepare_publication_datasets.py
@@ -37,7 +37,7 @@ def prepare_roadnet_ca(output_dir: Path) -> None:
         urllib.request.urlretrieve(ROADNET_CA_URL, archive)
 
     vertices: set[int] = set()
-    edge_count = 0
+    source_rows = 0
     with gzip.open(archive, "rt", encoding="utf-8") as src, normalized.open("w", encoding="utf-8") as dst:
         for line in src:
             stripped = line.strip()
@@ -51,21 +51,28 @@ def prepare_roadnet_ca(output_dir: Path) -> None:
             dst.write(f"{u} {v}\n")
             vertices.add(u)
             vertices.add(v)
-            edge_count += 1
+            source_rows += 1
 
+    # SNAP's roadNet-CA text file contains both orientations of each undirected
+    # road. The public dataset page reports 2,766,607 undirected edges, while
+    # the source text therefore contains 5,533,214 non-comment edge rows.
+    expected_vertices = 1965206
+    expected_undirected_edges = 2766607
+    expected_source_rows = expected_undirected_edges * 2
     record = {
         "dataset": "roadNet-CA",
         "source_url": ROADNET_CA_URL,
         "source_sha256": sha256_file(archive),
         "normalized_sha256": sha256_file(normalized),
         "vertices_observed": len(vertices),
-        "undirected_edges_observed": edge_count,
-        "normalization": "comments removed; self-loops removed; source undirected edge orientation preserved",
-        "expected_source_vertices": 1965206,
-        "expected_source_undirected_edges": 2766607,
+        "source_edge_rows_observed": source_rows,
+        "expected_source_vertices": expected_vertices,
+        "expected_source_edge_rows": expected_source_rows,
+        "expected_undirected_edges": expected_undirected_edges,
+        "normalization": "comments removed; self-loops removed; both source orientations retained; VeloGraphX undirected loader canonicalizes duplicate reciprocal input",
     }
     metadata.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
-    if record["vertices_observed"] != record["expected_source_vertices"] or record["undirected_edges_observed"] != record["expected_source_undirected_edges"]:
+    if record["vertices_observed"] != expected_vertices or record["source_edge_rows_observed"] != expected_source_rows:
         raise RuntimeError("roadNet-CA provenance counts do not match the publication contract")
     print(json.dumps(record, indent=2))
 

--- a/scripts/prepare_publication_datasets.py
+++ b/scripts/prepare_publication_datasets.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Prepare publication benchmark datasets with provenance metadata.
+
+Examples:
+  python3 scripts/prepare_publication_datasets.py roadnet-ca --output-dir data
+  python3 scripts/prepare_publication_datasets.py kronecker --output-dir data --scale 20 --seed 1
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import random
+import urllib.request
+from pathlib import Path
+
+ROADNET_CA_URL = "https://snap.stanford.edu/data/roadNet-CA.txt.gz"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def prepare_roadnet_ca(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    archive = output_dir / "roadNet-CA.txt.gz"
+    normalized = output_dir / "roadNet-CA.edges"
+    metadata = output_dir / "roadNet-CA.metadata.json"
+
+    if not archive.exists():
+        urllib.request.urlretrieve(ROADNET_CA_URL, archive)
+
+    vertices: set[int] = set()
+    edge_count = 0
+    with gzip.open(archive, "rt", encoding="utf-8") as src, normalized.open("w", encoding="utf-8") as dst:
+        for line in src:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            u_text, v_text = stripped.split()[:2]
+            u = int(u_text)
+            v = int(v_text)
+            if u == v:
+                continue
+            dst.write(f"{u} {v}\n")
+            vertices.add(u)
+            vertices.add(v)
+            edge_count += 1
+
+    record = {
+        "dataset": "roadNet-CA",
+        "source_url": ROADNET_CA_URL,
+        "source_sha256": sha256_file(archive),
+        "normalized_sha256": sha256_file(normalized),
+        "vertices_observed": len(vertices),
+        "undirected_edges_observed": edge_count,
+        "normalization": "comments removed; self-loops removed; source undirected edge orientation preserved",
+        "expected_source_vertices": 1965206,
+        "expected_source_undirected_edges": 2766607,
+    }
+    metadata.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+    if record["vertices_observed"] != record["expected_source_vertices"] or record["undirected_edges_observed"] != record["expected_source_undirected_edges"]:
+        raise RuntimeError("roadNet-CA provenance counts do not match the publication contract")
+    print(json.dumps(record, indent=2))
+
+
+def generate_kronecker(output_dir: Path, scale: int, edgefactor: int, seed: int) -> None:
+    if scale <= 0 or scale >= 32:
+        raise ValueError("scale must be in [1, 31] for VeloGraphX uint32 vertex IDs")
+    if edgefactor <= 0:
+        raise ValueError("edgefactor must be positive")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"kron-scale{scale}-ef{edgefactor}-seed{seed}.edges"
+    metadata = path.with_suffix(".metadata.json")
+    rng = random.Random(seed)
+    n = 1 << scale
+    m = edgefactor * n
+    probabilities = (0.57, 0.19, 0.19, 0.05)
+
+    with path.open("w", encoding="utf-8") as handle:
+        for _ in range(m):
+            u = 0
+            v = 0
+            step = n >> 1
+            while step:
+                r = rng.random()
+                if r < probabilities[0]:
+                    pass
+                elif r < probabilities[0] + probabilities[1]:
+                    v += step
+                elif r < probabilities[0] + probabilities[1] + probabilities[2]:
+                    u += step
+                else:
+                    u += step
+                    v += step
+                step >>= 1
+            handle.write(f"{u} {v}\n")
+
+    record = {
+        "dataset": "kronecker",
+        "generator": "Graph500-style R-MAT initiator; deterministic Python reference generator",
+        "scale": scale,
+        "vertices": n,
+        "edgefactor": edgefactor,
+        "generated_edge_tuples": m,
+        "A": probabilities[0],
+        "B": probabilities[1],
+        "C": probabilities[2],
+        "D": probabilities[3],
+        "seed": seed,
+        "sha256": sha256_file(path),
+        "notes": "Raw tuple stream intentionally retains self-loops and duplicate edges; graph loaders may canonicalize according to their documented semantics.",
+    }
+    metadata.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(record, indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    road = subparsers.add_parser("roadnet-ca")
+    road.add_argument("--output-dir", type=Path, required=True)
+
+    kron = subparsers.add_parser("kronecker")
+    kron.add_argument("--output-dir", type=Path, required=True)
+    kron.add_argument("--scale", type=int, required=True)
+    kron.add_argument("--edgefactor", type=int, default=16)
+    kron.add_argument("--seed", type=int, default=1)
+
+    args = parser.parse_args()
+    if args.command == "roadnet-ca":
+        prepare_roadnet_ca(args.output_dir)
+    else:
+        generate_kronecker(args.output_dir, args.scale, args.edgefactor, args.seed)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements the benchmark-methodology and tooling changes requested in #20 following John Owens' Gunrock feedback.

### Changes

- makes scale-free, road-network, and Graph500-style Kronecker graph families explicit publication requirements
- adds a machine-readable publication benchmark contract
- adds reproducible `roadNet-CA` acquisition/provenance and deterministic Kronecker generation tooling
- defines largest-practical in-memory scaling requirements
- defines a neutral standard-input boundary for end-to-end comparisons
- separates preprocessing-inclusive end-to-end timing from steady-state/kernel timing
- adds an external-baseline timing ledger so preprocessing/conversion costs cannot differ silently
- updates the public dataset benchmark to emit per-kernel preprocessing-inclusive timing alongside kernel-only timing
- adds an Owens benchmark workflow that executes real road-network and Kronecker smoke runs and retains provenance/timing artifacts

All repository CI and contract workflows pass on the final branch revision. Issue #20 remains open only for the dedicated-hardware largest-practical in-memory capacity experiment; hosted CI smoke evidence is not being mislabeled as publication-grade capacity evidence.