### PR TITLE
Fix all current adaptive policy CI schema regressions

### DIFF
--- a/.github/workflows/adaptive-policy-ablation.yml
+++ b/.github/workflows/adaptive-policy-ablation.yml
@@ -119,10 +119,27 @@ jobs:
             echo "epinions_gzip_sha256=69a2dab71fa5e3a0715487599fc16ca17ddc847379325a6c765bbad6e3e36938"
             echo "epinions_text_sha256=$EPINIONS_TEXT_SHA256"
             echo "simple_update_fraction=$SIMPLE_UPDATE_FRACTION"
-            echo "adaptive_affected_fraction=0.35"
             echo "repetitions_per_regime=5"
             echo "one_thread=true"
           } > build/policy/pins.txt
+          python - <<'PY' >> build/policy/pins.txt
+          import json
+          from pathlib import Path
+
+          paths = sorted(Path('build/policy/runs').glob('*.json'))
+          if not paths:
+              raise SystemExit('no policy result available for threshold pinning')
+          first = json.loads(paths[0].read_text())
+          thresholds = first.get('thresholds')
+          if not isinstance(thresholds, dict) or not thresholds:
+              raise SystemExit('policy result does not contain selector thresholds')
+          for path in paths[1:]:
+              current = json.loads(path.read_text()).get('thresholds')
+              if current != thresholds:
+                  raise SystemExit(f'selector thresholds changed within run: {path}')
+          for key in sorted(thresholds):
+              print(f'selector_{key}={thresholds[key]}')
+          PY
 
       - uses: actions/upload-artifact@v4
         with:

--- a/tools/summarize_adaptive_policy.py
+++ b/tools/summarize_adaptive_policy.py
@@ -9,6 +9,55 @@ from pathlib import Path
 POLICIES = ["always_incremental", "always_full", "simple_threshold", "adaptive"]
 
 
+def mean(values):
+    if not values:
+        raise ValueError("cannot compute a mean from an empty sequence")
+    return sum(values) / len(values)
+
+
+def policy_regret(result, oracle_batch_us, path):
+    """Return mean per-batch oracle-relative regret for old and schema-v6 records."""
+    if "regret_vs_batch_oracle" in result:
+        return float(result["regret_vs_batch_oracle"])
+
+    batch_us = result.get("batch_us")
+    if not isinstance(batch_us, list) or not isinstance(oracle_batch_us, list):
+        raise SystemExit(f"missing batch_us/oracle_batch_us needed for regret: {path}")
+    if len(batch_us) != len(oracle_batch_us) or not batch_us:
+        raise SystemExit(
+            f"mismatched or empty batch/oracle timings in {path}: "
+            f"{len(batch_us)} vs {len(oracle_batch_us)}"
+        )
+
+    regrets = []
+    for observed, oracle in zip(batch_us, oracle_batch_us):
+        observed = float(observed)
+        oracle = float(oracle)
+        if oracle < 0.0 or observed < 0.0:
+            raise SystemExit(f"negative timing in {path}")
+        if oracle == 0.0:
+            regret = 0.0 if observed == 0.0 else math.inf
+        else:
+            regret = (observed - oracle) / oracle
+        if not math.isfinite(regret):
+            raise SystemExit(f"non-finite oracle regret in {path}")
+        # The oracle is the minimum observed policy latency for each batch. Tiny
+        # negative values can only arise from floating-point roundoff.
+        regrets.append(max(0.0, regret))
+    return mean(regrets)
+
+
+def is_policy_record(d):
+    """Accept the historical tagged artifact and the current schema-v6 harness."""
+    if d.get("artifact_type") == "velographx-adaptive-policy-ablation":
+        return True
+    return (
+        int(d.get("schema_version", 0)) >= 6
+        and isinstance(d.get("policies"), list)
+        and isinstance(d.get("oracle_batch_us"), list)
+    )
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--input-dir", type=Path, required=True)
@@ -17,37 +66,66 @@ def main():
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
     grouped = defaultdict(list)
+    inspected = 0
     for path in sorted(args.input_dir.glob("*.json")):
+        inspected += 1
         d = json.loads(path.read_text())
-        if d.get("artifact_type") != "velographx-adaptive-policy-ablation":
+        if not is_policy_record(d):
             continue
         parts = path.stem.split("__")
         if len(parts) < 3:
             continue
-        dataset, batch, rep = parts[0], int(parts[1]), int(parts[2])
+        try:
+            dataset, batch, rep = parts[0], int(parts[1]), int(parts[2])
+        except ValueError as exc:
+            raise SystemExit(f"invalid policy result filename: {path}") from exc
         if not d.get("all_policies_exact"):
             raise SystemExit(f"inexact policy result: {path}")
-        grouped[(dataset, batch)].append((rep, d))
+        if not all(p.get("exact") for p in d.get("policies", [])):
+            raise SystemExit(f"inexact per-policy result: {path}")
+        grouped[(dataset, batch)].append((rep, path, d))
+
+    if not grouped:
+        raise SystemExit(
+            f"no adaptive-policy result artifacts found in {args.input_dir} "
+            f"after inspecting {inspected} JSON file(s)"
+        )
 
     rows = []
     dataset_summary = defaultdict(list)
     for (dataset, batch), reps in sorted(grouped.items()):
         if len(reps) != 5:
             raise SystemExit(f"expected five repetitions for {dataset}/{batch}, got {len(reps)}")
+        rep_ids = sorted(rep for rep, _, _ in reps)
+        if rep_ids != [1, 2, 3, 4, 5]:
+            raise SystemExit(f"expected repetitions 1..5 for {dataset}/{batch}, got {rep_ids}")
+
         metrics = {p: {"means": [], "regrets": [], "full": []} for p in POLICIES}
-        for _, d in reps:
-            by_name = {p["name"]: p for p in d["policies"]}
+        for _, path, d in reps:
+            by_name = {p.get("name"): p for p in d["policies"]}
+            missing = [policy for policy in POLICIES if policy not in by_name]
+            if missing:
+                raise SystemExit(f"missing policies {missing} in {path}")
+            oracle_batch_us = d.get("oracle_batch_us")
             for policy in POLICIES:
                 p = by_name[policy]
-                metrics[policy]["means"].append(p["mean_batch_us"])
-                metrics[policy]["regrets"].append(p["regret_vs_batch_oracle"])
-                metrics[policy]["full"].append(p["full_recompute_batches"])
-        policy_means = {p: sum(metrics[p]["means"]) / 5 for p in POLICIES}
+                batch_us = p.get("batch_us")
+                if "mean_batch_us" in p:
+                    mean_batch_us = float(p["mean_batch_us"])
+                elif isinstance(batch_us, list) and batch_us:
+                    mean_batch_us = mean(float(x) for x in batch_us)
+                else:
+                    raise SystemExit(f"missing mean/batch latency for {policy} in {path}")
+                metrics[policy]["means"].append(mean_batch_us)
+                metrics[policy]["regrets"].append(policy_regret(p, oracle_batch_us, path))
+                metrics[policy]["full"].append(float(p["full_recompute_batches"]))
+
+        policy_means = {p: mean(metrics[p]["means"]) for p in POLICIES}
         best = min(policy_means, key=policy_means.get)
         for policy in POLICIES:
             mean_us = policy_means[policy]
-            regret = sum(metrics[policy]["regrets"]) / 5
-            full = sum(metrics[policy]["full"]) / 5
+            regret = mean(metrics[policy]["regrets"])
+            full = mean(metrics[policy]["full"])
             row = {
                 "dataset": dataset,
                 "batch_size": batch,
@@ -64,11 +142,14 @@ def main():
     csv_path = args.output_dir / "policy-regime-summary.csv"
     with csv_path.open("w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
-        writer.writeheader(); writer.writerows(rows)
+        writer.writeheader()
+        writer.writerows(rows)
 
     summary = {
-        "schema_version": 1,
+        "schema_version": 2,
         "artifact_type": "velographx-adaptive-policy-crossover-summary",
+        "input_schema_compatibility": ["historical-tagged", "schema-v6"],
+        "regret_definition": "mean per-batch max(0, (policy_us - oracle_us) / oracle_us)",
         "repetitions_per_regime": 5,
         "all_results_exact": True,
         "rows": rows,
@@ -76,12 +157,14 @@ def main():
     }
     for dataset, dsrows in dataset_summary.items():
         adaptive = [r for r in dsrows if r["policy"] == "adaptive"]
+        if not adaptive:
+            raise SystemExit(f"no adaptive rows summarized for {dataset}")
         wins = sum(r["fastest_policy_for_regime"] == "adaptive" for r in adaptive)
         summary["datasets"][dataset] = {
             "regimes": len(adaptive),
             "adaptive_regime_wins": wins,
-            "adaptive_mean_regret": sum(r["mean_regret_vs_batch_oracle"] for r in adaptive) / len(adaptive),
-            "adaptive_mean_relative_to_regime_best": sum(r["relative_to_regime_best"] for r in adaptive) / len(adaptive),
+            "adaptive_mean_regret": mean(r["mean_regret_vs_batch_oracle"] for r in adaptive),
+            "adaptive_mean_relative_to_regime_best": mean(r["relative_to_regime_best"] for r in adaptive),
             "crossover": [
                 {"batch_size": r["batch_size"], "fastest_policy": r["fastest_policy_for_regime"]}
                 for r in adaptive


### PR DESCRIPTION
Fixes the remaining post-#23 adaptive-policy workflow failures found through GitHub Actions and Gmail alerts.

- Updates `tools/summarize_adaptive_policy.py` for schema-v6 policy artifacts while retaining historical compatibility.
- Computes per-batch oracle regret from current `batch_us` / `oracle_batch_us` records instead of assuming removed summary fields.
- Adds explicit validation for empty/malformed result sets, missing policies, repetition coverage, and exactness.
- Fixes Adaptive BFS Policy Ablation evidence provenance by deriving selector thresholds from generated benchmark JSON rather than a stale hard-coded `adaptive_affected_fraction=0.35` value.
- Verifies threshold consistency across every result in the run.

This shared summarizer fix addresses both the Adaptive BFS Policy Ablation failure on main and the Adaptive BFS Policy Multi-root Validation failure observed after the #23 merge; in both workflows the benchmark executions and exactness checks completed successfully before the old summarizer failed.