### PR TITLE
Fix adaptive policy generator aggregation failure

### DIFF
--- a/tools/summarize_adaptive_policy.py
+++ b/tools/summarize_adaptive_policy.py
@@ -10,6 +10,7 @@ POLICIES = ["always_incremental", "always_full", "simple_threshold", "adaptive"]
 
 
 def mean(values):
+    values = list(values)
     if not values:
         raise ValueError("cannot compute a mean from an empty sequence")
     return sum(values) / len(values)


### PR DESCRIPTION
Fixes the new Adaptive BFS Policy Ablation failure on `main` after the schema-v6 summarizer update.

Root cause: the shared `mean()` helper used `len(values)` directly, but several new summary paths pass generators. The benchmark sweep itself completed successfully with exact results; only aggregation failed with `TypeError: object of type 'generator' has no len()`.

The helper now materializes any iterable once before empty-checking, summing, and measuring length. This keeps list behavior unchanged and makes generator-based summary calls safe across both ablation and multi-root workflows.