### PR TITLE
Complete non-intrusive graph abstraction and Teseo evidence

### DIFF
--- a/.github/workflows/external-teseo-storage.yml
+++ b/.github/workflows/external-teseo-storage.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build Teseo release configuration
         working-directory: external/teseo
         run: |
-          ./autoreconf -iv
+          autoreconf -iv
           mkdir build
           cd build
           ../configure --enable-optimize --disable-debug

--- a/.github/workflows/external-teseo-storage.yml
+++ b/.github/workflows/external-teseo-storage.yml
@@ -1,0 +1,120 @@
+name: External Teseo Storage Evidence
+
+on:
+  push:
+    paths:
+      - '.github/workflows/external-teseo-storage.yml'
+      - 'benchmarks/external_teseo_storage_bfs.cpp'
+      - 'include/velographx/graph_access.hpp'
+      - 'include/velographx/incremental/bfs.hpp'
+      - 'tests/test_graph_access_adl.cpp'
+      - 'CMakeLists.txt'
+  pull_request:
+    paths:
+      - '.github/workflows/external-teseo-storage.yml'
+      - 'benchmarks/external_teseo_storage_bfs.cpp'
+      - 'include/velographx/graph_access.hpp'
+      - 'include/velographx/incremental/bfs.hpp'
+      - 'tests/test_graph_access_adl.cpp'
+      - 'CMakeLists.txt'
+  workflow_dispatch:
+
+jobs:
+  teseo-storage-swap:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    env:
+      TESEO_SHA: 2c37c2831c4d2acaaa838a86e1318363ce68c45b
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake libtool pkg-config libnuma-dev libevent-dev
+
+      - name: Build and test VeloGraphX abstraction contract
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DVELOGRAPHX_BUILD_TESTS=ON -DVELOGRAPHX_BUILD_BENCHMARKS=OFF
+          cmake --build build --parallel 2
+          ctest --test-dir build --output-on-failure
+
+      - name: Clone pinned Teseo
+        run: |
+          git clone https://github.com/cwida/teseo.git external/teseo
+          git -C external/teseo checkout "$TESEO_SHA"
+          test "$(git -C external/teseo rev-parse HEAD)" = "$TESEO_SHA"
+
+      - name: Build Teseo release configuration
+        working-directory: external/teseo
+        run: |
+          ./autoreconf -iv
+          mkdir build
+          cd build
+          ../configure --enable-optimize --disable-debug
+          make -j2
+          test -f libteseo.a
+
+      - name: Compile same-algorithm storage benchmark
+        run: |
+          c++ -O3 -DNDEBUG -std=c++20 \
+            -Iinclude \
+            -Iexternal/teseo/include \
+            -Iexternal/teseo/build/include \
+            benchmarks/external_teseo_storage_bfs.cpp \
+            build/libvelographx.a \
+            external/teseo/build/libteseo.a \
+            -lnuma -levent_pthreads -levent_core -pthread \
+            -o build/velographx_external_teseo_storage_bfs
+
+      - name: Run exact storage-swap campaign
+        run: |
+          mkdir -p artifacts/teseo
+          build/velographx_external_teseo_storage_bfs 8192 | tee artifacts/teseo/teseo-8192.json
+          build/velographx_external_teseo_storage_bfs 32768 | tee artifacts/teseo/teseo-32768.json
+
+      - name: Validate result contract
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          for path in sorted(Path('artifacts/teseo').glob('teseo-*.json')):
+              row = json.loads(path.read_text())
+              assert row['schema_version'] == 1
+              assert row['benchmark'] == 'same-algorithm-storage-bfs'
+              assert row['algorithm'] == 'BasicIncrementalBFS::recompute'
+              assert row['repetitions'] == 5
+              assert row['exact'] is True
+              assert row['dynamic_graph_median_us'] > 0
+              assert row['csr_graph_median_us'] > 0
+              assert row['teseo_median_us'] > 0
+          PY
+
+      - name: Record immutable experiment metadata
+        run: |
+          python - <<'PY'
+          import json, os, platform, subprocess
+          from pathlib import Path
+          payload = {
+              'schema_version': 1,
+              'artifact_type': 'velographx-teseo-storage-swap',
+              'publication_grade': False,
+              'same_algorithm': 'BasicIncrementalBFS::recompute',
+              'teseo_commit': os.environ['TESEO_SHA'],
+              'teseo_semantics': 'undirected simple weighted graph; unit weights; dense vertex IDs',
+              'compiler': subprocess.check_output(['c++', '--version'], text=True).splitlines()[0],
+              'platform': platform.platform(),
+              'runner': 'github-hosted ubuntu-22.04',
+              'timing_scope': 'five median recomputations after graph construction; input/build time excluded',
+              'claim_gate': 'engineering storage-swap evidence only; not publication-grade hardware evidence',
+          }
+          Path('artifacts/teseo/metadata.json').write_text(json.dumps(payload, indent=2, sort_keys=True) + '\n')
+          PY
+
+      - name: Upload evidence only
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: velographx-teseo-storage-swap
+          path: artifacts/teseo
+          retention-days: 30

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(velographx_dynamic_example PRIVATE velographx)
 
 if(VELOGRAPHX_BUILD_TESTS)
   enable_testing()
-  set(VELOGRAPHX_TESTS static dynamic consolidation_controller incremental incremental_bfs_deletion incremental_components_deletion kcore_localized pagerank_localized storage_independence io io_hardening kernels weighted_sssp numa numa_policy numa_partitioner numa_scheduler work_stealing work_stealing_stress degree_frontier_scheduler execution_plan compression compression_policy temporal randomized_dynamic partition_cache partition_file async_partition_loader)
+  set(VELOGRAPHX_TESTS static dynamic consolidation_controller incremental incremental_bfs_deletion incremental_components_deletion kcore_localized pagerank_localized storage_independence graph_access_adl io io_hardening kernels weighted_sssp numa numa_policy numa_partitioner numa_scheduler work_stealing work_stealing_stress degree_frontier_scheduler execution_plan compression compression_policy temporal randomized_dynamic partition_cache partition_file async_partition_loader)
   foreach(test_name IN LISTS VELOGRAPHX_TESTS)
     set(test_source "${PROJECT_SOURCE_DIR}/tests/test_${test_name}.cpp")
     if(NOT EXISTS "${test_source}")

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ VeloGraphX is a C++20 CPU engine for **exact analytics on changing graphs**. It 
 - Makes the incremental/full crossover explicit: the selector owns the decision before excessive repair work is incurred.
 - Treats **exactness as a benchmark gate**: incremental outputs are checked against independent full recomputation/reference implementations.
 - Uses scale, root-locality, affected-work and observed-cost signals; policy quality is evaluated on pinned datasets, multiple roots/regimes and retained artifacts.
+- Separates algorithms from graph representation through a **non-intrusive C++20 graph-access contract**, so the same algorithm can be exercised over mutable storage, read-optimised CSR and foreign graph representations.
 
-See [related-work positioning](docs/related-work-positioning.md) and the [ablation study](docs/ablation-study.md).
+See [related-work positioning](docs/related-work-positioning.md), the [graph abstraction](docs/graph-abstraction.md), and the [ablation study](docs/ablation-study.md).
 
 ## Results
 
@@ -26,6 +27,7 @@ GitHub-hosted results below are **engineering evidence, not publication-grade ha
 | Dynamic exactness stress | **2,000,000 updates; 0 BFS / 0 triangle mismatches** | 6 adversarial scenarios; independent check after every batch |
 | Refined adaptive BFS | **108/108 exact; 1.66% mean overhead from regime-best** | 3 datasets × 4 roots × 3 regimes × 3 reps |
 | `web-Google` adaptive BFS | **1.17% mean overhead** | down from 25.8% in the pre-refinement campaign |
+| External storage swap | **exact across DynamicGraph / CSR / Teseo** | identical `BasicIncrementalBFS::recompute`, 5 reps |
 | Multicore BFS workload | **2.74× at 4 threads (~69% efficiency)** | 50K vertices, degree 8, 32 independent tasks, median of 5 reps |
 | Connected-components workload | **2.50× at 4 threads (~62%)** | same workload contract |
 | Triangle-count workload | **2.24× at 4 threads (~56%)** | same workload contract |
@@ -61,7 +63,18 @@ Native C++, one OpenMP thread, same machine/update stream, five paired repetitio
 
 VeloGraphX wins the larger `web-Google` case but **loses on `ca-GrQc`**. NetworKit revision `359f3fbf09b6d3fe214db24dd01bc8bfc1c2653c`; run `33301190847`, artifact `9766977170`.
 
-RisGraph and other dynamic systems are relevant prior work, but results from different runners or incompatible semantics are intentionally **not merged into this table**.
+### Same-algorithm storage swap: Teseo
+
+This experiment keeps `BasicIncrementalBFS::recompute()` fixed and changes only the graph representation. Graph construction is outside the timer; five recomputations are run and the median is reported. Full distance vectors must match.
+
+| Vertices / edges | `DynamicGraph` | `CsrGraph` | Teseo adapter | Exact |
+| --- | ---: | ---: | ---: | :---: |
+| 8,192 / 32,768 | 120.434 µs | **57.988 µs** | 4,341.401 µs | yes |
+| 32,768 / 131,072 | 500.383 µs | **234.284 µs** | 21,854.866 µs | yes |
+
+Read-optimised CSR is about **2.08×–2.14× faster** than the mutable VeloGraphX representation for full recomputation on these cases. Using the same VeloGraphX BFS implementation, `DynamicGraph` traversal is about **36×–44× faster than the Teseo iterator adapter**. This is deliberately a **storage-interface experiment, not a system-level claim against Teseo's own algorithms or capabilities**. Teseo commit `2c37c2831c4d2acaaa838a86e1318363ce68c45b`; run `33475389747`, artifact `9787994251`. See [Teseo storage evidence](docs/teseo-storage-evidence.md).
+
+RisGraph and other dynamic systems remain relevant prior work; results from different runners or incompatible semantics are intentionally **not merged into same-semantics tables**.
 
 ## How it works
 
@@ -77,7 +90,7 @@ localized exact repair  ← selector →  full recomputation
 exact maintained result
 ```
 
-Implemented analytics include BFS/unweighted SSSP, weighted SSSP, connected components, triangle count, k-core and PageRank-related paths. Runtime/storage code also includes SIMD intersections, work stealing, NUMA-aware policies, compression, partition caching and asynchronous partition loading.
+Implemented analytics include BFS/unweighted SSSP, weighted SSSP, connected components, triangle count, k-core and PageRank-related paths. Generic unweighted algorithms use the C++20 graph-access layer rather than a concrete storage type; the weighted SSSP path currently retains a specialised weighted-graph contract while sharing the common Dijkstra engine. Runtime/storage code also includes SIMD intersections, work stealing, NUMA-aware policies, compression, partition caching and asynchronous partition loading.
 
 ## Quick Start
 
@@ -93,7 +106,7 @@ ctest --test-dir build --output-on-failure
 ./build/velographx_dynamic_example
 ```
 
-The default build includes **28 CTest targets** plus benchmark executables.
+The default build includes **29 CTest targets** plus benchmark executables. One test uses an ADL-only foreign graph type to prevent accidental coupling of generic algorithms back to VeloGraphX storage members.
 
 ## Reproduce
 
@@ -106,24 +119,26 @@ c++ -O3 -DNDEBUG -std=c++20 -Iinclude benchmarks/exactness_stress.cpp build/libv
 ./build/exactness_stress 2000000 256
 ```
 
-The refined 108-execution selector campaign and native competitor campaign are encoded as workflows so dataset/version pins, correctness gates and artifacts stay with the run.
+The refined selector, native competitor and Teseo storage-swap campaigns are encoded as workflows so version pins, correctness gates and artifacts stay with the run.
 
 ```bash
 # Requires an authenticated GitHub CLI.
 gh workflow run adaptive-selector-refinement.yml --ref main
 gh workflow run hosted-native-competitors.yml --ref main
+gh workflow run external-teseo-storage.yml --ref main
 
 gh run list --workflow adaptive-selector-refinement.yml --limit 1
 gh run list --workflow hosted-native-competitors.yml --limit 1
+gh run list --workflow external-teseo-storage.yml --limit 1
 ```
 
-Benchmark contracts and interpretation rules: [benchmark methodology](docs/benchmark-methodology.md), [native competitors](docs/hosted-native-competitors.md), [limitations](docs/limitations.md).
+Benchmark contracts and interpretation rules: [benchmark methodology](docs/benchmark-methodology.md), [graph abstraction](docs/graph-abstraction.md), [native competitors](docs/hosted-native-competitors.md), [limitations](docs/limitations.md).
 
 ## Limitations / Roadmap
 
-**Current:** hosted CI establishes exactness/reproducibility, 1/2/4-thread engineering behavior, compressed-storage trade-offs and same-run native comparisons. The refined adaptive selector averages **1.66% overhead from regime-best** on the tested 36 root/regime configurations, but this is not evidence of universal selector optimality. Compression saves space but currently slows BFS traversal.
+**Current:** hosted CI establishes exactness/reproducibility, 1/2/4-thread engineering behavior, compressed-storage trade-offs, same-run native comparisons and a pinned same-algorithm Teseo storage swap. The refined adaptive selector averages **1.66% overhead from regime-best** on the tested 36 root/regime configurations, but this is not evidence of universal selector optimality. The Teseo experiment isolates one BFS/storage interface on small synthetic graphs and is not a general Teseo performance comparison. Compression saves space but currently slows BFS traversal.
 
-**Next:** held-out graph families and roots for selector generalization; dedicated 8/16/32+ core experiments; true multi-socket NUMA measurements; broader same-machine dynamic-system comparisons; dedicated NVMe/`io_uring` throughput; hardware counters; broader weighted-dynamic evaluation; a frozen long-term Python API. See [limitations](docs/limitations.md).
+**Next:** held-out graph families and roots for selector generalization; dedicated 8/16/32+ core experiments; true multi-socket NUMA measurements; broader same-machine dynamic-system comparisons; a second external storage adapter such as Sortledton; dedicated NVMe/`io_uring` throughput; hardware counters; broader weighted-dynamic evaluation; a frozen long-term Python API. See [limitations](docs/limitations.md).
 
 ## License / Contributing
 

--- a/benchmarks/external_teseo_storage_bfs.cpp
+++ b/benchmarks/external_teseo_storage_bfs.cpp
@@ -1,0 +1,151 @@
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "teseo.hpp"
+#include "velographx/csr_graph.hpp"
+#include "velographx/incremental/bfs.hpp"
+#include "velographx/storage/dynamic_graph.hpp"
+
+namespace teseo_adapter {
+
+using velographx::VertexId;
+
+class Graph {
+ public:
+  Graph(std::size_t vertices, const std::vector<std::pair<VertexId, VertexId>>& edges)
+      : vertices_(vertices) {
+    auto tx = database_.start_transaction();
+    for (std::size_t v = 0; v < vertices_; ++v) tx.insert_vertex(v);
+    for (const auto& [u, v] : edges) tx.insert_edge(u, v, 1.0);
+    tx.commit();
+  }
+
+  Graph(const Graph&) = delete;
+  Graph& operator=(const Graph&) = delete;
+
+  ~Graph() {
+    if (iterator_) iterator_->close();
+    if (snapshot_) snapshot_->commit();
+  }
+
+  void ensure_snapshot() const {
+    if (snapshot_) return;
+    snapshot_ = std::make_unique<teseo::Transaction>(database_.start_transaction(true));
+    iterator_ = std::make_unique<teseo::Iterator>(snapshot_->iterator());
+  }
+
+  mutable teseo::Teseo database_;
+  std::size_t vertices_{0};
+  mutable std::unique_ptr<teseo::Transaction> snapshot_;
+  mutable std::unique_ptr<teseo::Iterator> iterator_;
+};
+
+// Non-intrusive customization only: Graph intentionally has no vertex_count(),
+// directed(), neighbors(), or for_each_neighbor() member functions.
+std::size_t vx_vertex_count(const Graph& graph) { return graph.vertices_; }
+bool vx_is_directed(const Graph&) { return false; }
+
+template <class Fn>
+void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
+  graph.ensure_snapshot();
+  graph.iterator_->edges(static_cast<std::uint64_t>(u), false, [&](std::uint64_t destination) {
+    fn(static_cast<VertexId>(destination));
+  });
+}
+
+}  // namespace teseo_adapter
+
+namespace {
+
+using velographx::BasicIncrementalBFS;
+using velographx::CsrGraph;
+using velographx::DynamicGraph;
+using velographx::VertexId;
+
+std::vector<std::pair<VertexId, VertexId>> make_graph(std::size_t vertices) {
+  std::set<std::pair<VertexId, VertexId>> unique;
+  constexpr VertexId offsets[] = {1, 7, 31, 127};
+  for (VertexId u = 0; u < vertices; ++u) {
+    for (auto offset : offsets) {
+      VertexId v = static_cast<VertexId>((static_cast<std::size_t>(u) + offset) % vertices);
+      if (u == v) continue;
+      auto edge = std::minmax(u, v);
+      unique.insert({edge.first, edge.second});
+    }
+  }
+  return {unique.begin(), unique.end()};
+}
+
+template <class Graph>
+double median_recompute_us(Graph& graph, VertexId source, std::vector<std::uint32_t>& distances) {
+  BasicIncrementalBFS<Graph> bfs(graph, source);
+  std::vector<double> samples;
+  samples.reserve(5);
+  for (int rep = 0; rep < 5; ++rep) {
+    const auto start = std::chrono::steady_clock::now();
+    bfs.recompute();
+    const auto stop = std::chrono::steady_clock::now();
+    samples.push_back(std::chrono::duration<double, std::micro>(stop - start).count());
+  }
+  std::sort(samples.begin(), samples.end());
+  distances = bfs.distances();
+  return samples[samples.size() / 2];
+}
+
+std::uint64_t digest(const std::vector<std::uint32_t>& distances) {
+  std::uint64_t h = 1469598103934665603ULL;
+  for (auto d : distances) {
+    h ^= static_cast<std::uint64_t>(d);
+    h *= 1099511628211ULL;
+  }
+  return h;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  const std::size_t vertices = argc > 1 ? static_cast<std::size_t>(std::stoull(argv[1])) : 8192;
+  const VertexId source = 0;
+  const auto edges = make_graph(vertices);
+
+  DynamicGraph dynamic(vertices, false);
+  dynamic.bulk_load_edges(edges);
+  CsrGraph csr(edges, false);
+  teseo_adapter::Graph teseo_graph(vertices, edges);
+
+  std::vector<std::uint32_t> dynamic_dist;
+  std::vector<std::uint32_t> csr_dist;
+  std::vector<std::uint32_t> teseo_dist;
+
+  const double dynamic_us = median_recompute_us(dynamic, source, dynamic_dist);
+  const double csr_us = median_recompute_us(csr, source, csr_dist);
+  const double teseo_us = median_recompute_us(teseo_graph, source, teseo_dist);
+
+  const bool exact = dynamic_dist == csr_dist && dynamic_dist == teseo_dist;
+  std::cout << std::fixed << std::setprecision(3)
+            << "{\"schema_version\":1,"
+            << "\"benchmark\":\"same-algorithm-storage-bfs\","
+            << "\"algorithm\":\"BasicIncrementalBFS::recompute\","
+            << "\"vertices\":" << vertices << ','
+            << "\"edges\":" << edges.size() << ','
+            << "\"source\":" << source << ','
+            << "\"repetitions\":5,"
+            << "\"exact\":" << (exact ? "true" : "false") << ','
+            << "\"digest\":" << digest(dynamic_dist) << ','
+            << "\"dynamic_graph_median_us\":" << dynamic_us << ','
+            << "\"csr_graph_median_us\":" << csr_us << ','
+            << "\"teseo_median_us\":" << teseo_us << ','
+            << "\"dynamic_over_csr\":" << (dynamic_us / csr_us) << ','
+            << "\"dynamic_over_teseo\":" << (dynamic_us / teseo_us)
+            << "}\n";
+
+  return exact ? 0 : 2;
+}

--- a/docs/graph-abstraction.md
+++ b/docs/graph-abstraction.md
@@ -4,18 +4,16 @@ VeloGraphX separates graph algorithms from graph representation so storage/layou
 
 ## Design
 
-The lightweight C++20 customisation layer is defined in `include/velographx/graph_access.hpp`. Algorithms depend on a small graph surface rather than a concrete `DynamicGraph` type:
+The lightweight C++20 customisation layer is defined in `include/velographx/graph_access.hpp`. Generic algorithms use free-function accessors such as `vertex_count`, `is_directed`, `for_each_neighbor`, `for_each_in_neighbor`, `has_edge`, and `apply_updates` rather than depending on a concrete `DynamicGraph` type.
 
-- `vertex_count()`
-- `directed()`
-- zero-copy/callback outgoing traversal
-- zero-copy/callback incoming traversal where required
-- `has_edge()` where required
-- `apply(batch)` for mutable incremental algorithms
+The accessors support two paths:
 
-No inheritance is required. A foreign representation can be used directly when it provides the required operations, or wrapped by a small adapter.
+1. an in-tree graph can provide the corresponding member operation;
+2. a foreign graph can opt in non-intrusively through ADL customisation hooks such as `vx_vertex_count`, `vx_is_directed`, `vx_for_each_neighbor`, `vx_for_each_in_neighbor`, `vx_has_edge`, and `vx_apply_updates`.
 
-The default public names (`IncrementalBFS`, `IncrementalSSSP`, `IncrementalComponents`, `IncrementalKCore`, `IncrementalPageRank`, `IncrementalTriangleCount`) remain aliases for `DynamicGraph` specialisations, preserving source compatibility. The reusable implementations are `BasicIncremental*<Graph>` templates.
+No inheritance, base class, or modification of the foreign graph type is required. This is a BGL-style non-intrusive customisation approach implemented with C++20 concepts rather than a claim of Boost.Graph API compatibility.
+
+The default public names (`IncrementalBFS`, `IncrementalSSSP`, `IncrementalComponents`, `IncrementalKCore`, `IncrementalPageRank`, `IncrementalTriangleCount`) preserve the normal `DynamicGraph` API. Reusable implementations are `BasicIncremental*<Graph>` templates. Weighted SSSP currently keeps a specialised weighted-graph contract while sharing the common Dijkstra queue/relaxation engine.
 
 ## Backends
 
@@ -26,15 +24,17 @@ Two in-tree backends exercise the same algorithm implementations:
 
 `CsrGraph` deliberately does not implement mutation. It is used as a read-optimised recomputation backend and as a controlled storage baseline.
 
+A third, external backend is now exercised in CI through an ADL-only Teseo adapter. See [Teseo same-algorithm storage evidence](teseo-storage-evidence.md).
+
 ## Zero-allocation traversal
 
-Hot algorithm paths use callback traversal (`for_each_neighbor` / `for_each_in_neighbor`) rather than materialising `std::vector` adjacency lists. `DynamicGraph::neighbors()` remains available as a compatibility/materialisation API, but the core incremental algorithms no longer rely on it. `WeightedDynamicGraph` likewise provides allocation-free callback traversal.
+Hot algorithm paths use callback traversal (`for_each_neighbor` / `for_each_in_neighbor`) rather than materialising `std::vector` adjacency lists. `DynamicGraph::neighbors()` remains available as a compatibility/materialisation API, but the generic incremental algorithms do not need it. `WeightedDynamicGraph` likewise provides allocation-free callback traversal.
 
 ## Shared SSSP implementation
 
-Weighted and unweighted SSSP share the queue/relaxation engine in `incremental/dijkstra.hpp`. The only varying input is the edge-weight enumeration: unit cost for unweighted graphs and stored weights for weighted graphs.
+Weighted and unweighted SSSP share the queue/relaxation engine in `incremental/dijkstra.hpp`. The varying input is the edge-weight enumeration: unit cost for unweighted graphs and stored weights for weighted graphs.
 
-## Controlled benchmark
+## Controlled in-tree benchmark
 
 `velographx_backend_bfs_benchmark` runs the exact same `BasicIncrementalBFS<Graph>::recompute()` implementation against `DynamicGraph` and `CsrGraph` and fails if distance vectors differ.
 
@@ -46,25 +46,30 @@ Example:
 
 The JSON output reports both timings and `correctness_match:true`.
 
-This benchmark is intended to answer a storage question: with algorithm semantics fixed, how much does the representation change recomputation latency?
+This benchmark answers a storage question: with algorithm semantics fixed, how much does the representation change recomputation latency?
 
-## Correctness test
+## Correctness tests
 
 `test_storage_independence.cpp` executes identical algorithm templates on `DynamicGraph` and `CsrGraph` for BFS, unweighted SSSP, connected components, k-core, triangle counting, and PageRank. Results are checked for exact equality where appropriate and a tight numerical tolerance for PageRank.
 
+`test_graph_access_adl.cpp` goes further: it defines a foreign graph type with no VeloGraphX-style graph member API and adapts it only through ADL free functions. `BasicIncrementalBFS` and `BasicIncrementalSSSP` are then exercised through insertion and deletion updates. This is the regression gate for the non-intrusive customisation contract.
+
 ## External dynamic graph adapters
 
-Teseo and Sortledton are appropriate candidates for future same-semantics storage experiments, but they are intentionally not mandatory build dependencies. A fair adapter must satisfy all of the following before benchmark numbers are reported:
+Teseo is now a real same-algorithm storage experiment rather than a future placeholder. The external workflow pins Teseo commit `2c37c2831c4d2acaaa838a86e1318363ce68c45b`, builds it from source, and runs the same `BasicIncrementalBFS::recompute()` implementation over `DynamicGraph`, `CsrGraph`, and the Teseo adapter. Full BFS distance vectors must match. The retained hosted evidence is documented in [teseo-storage-evidence.md](teseo-storage-evidence.md).
+
+A fair external adapter must satisfy all of the following before benchmark numbers are reported:
 
 - pin an immutable upstream revision/version;
-- use identical graph inputs and update streams;
+- use identical graph inputs and update streams or snapshots as required by the experiment;
 - preserve directed/undirected and duplicate/self-loop semantics;
-- keep the VeloGraphX algorithm implementation fixed;
+- keep the VeloGraphX algorithm implementation fixed for a storage-swap experiment;
 - separate conversion/build time from steady-state kernel time;
-- validate outputs against an independent reference;
-- report compiler flags, hardware, threads, NUMA placement and repetitions.
+- validate outputs against an independent or cross-backend reference;
+- report compiler flags, hardware, threads, NUMA placement and repetitions;
+- distinguish storage-interface evidence from a system-level comparison of each project's native algorithms.
 
-If an external system cannot expose the traversal/mutation semantics required by the same algorithm without changing the algorithm itself, it must be reported as a system-level comparison rather than a storage-swap experiment.
+Sortledton remains a useful additional backend for independent replication. It is not folded into the current table until an equally pinned, same-semantics adapter is validated.
 
 ## Experiment families
 
@@ -76,7 +81,8 @@ Hold algorithm and workload fixed:
 BasicIncrementalBFS::recompute
   -> DynamicGraph
   -> CsrGraph
-  -> external adapter (when semantics permit)
+  -> Teseo adapter
+  -> another external adapter when semantics permit
 ```
 
 ### Incremental repair vs recomputation

--- a/docs/teseo-storage-evidence.md
+++ b/docs/teseo-storage-evidence.md
@@ -1,0 +1,39 @@
+# Teseo same-algorithm storage evidence
+
+This experiment isolates **storage/layout effects** by running the exact same VeloGraphX BFS implementation, `BasicIncrementalBFS<Graph>::recompute()`, over three graph representations: VeloGraphX `DynamicGraph`, read-optimised `CsrGraph`, and an external Teseo adapter.
+
+The Teseo adapter is non-intrusive: the adapter graph does not expose VeloGraphX-style `vertex_count()`, `directed()`, `neighbors()`, or `for_each_neighbor()` members. It opts into the C++20 graph-access contract through ADL `vx_*` free functions. This is intended to demonstrate that a foreign representation can be used without inheritance or modifying the foreign library.
+
+## Contract
+
+- Teseo repository: `cwida/teseo`
+- pinned Teseo commit: `2c37c2831c4d2acaaa838a86e1318363ce68c45b`
+- algorithm: identical `BasicIncrementalBFS::recompute()` for all three representations
+- graph semantics: undirected simple graph, dense vertex IDs, unit-weight traversal
+- source: vertex `0`
+- repetitions: 5; table reports medians
+- timing: graph construction/loading excluded; only repeated recomputation is timed
+- correctness: complete BFS distance vectors must match across all three backends
+- runner: GitHub-hosted Ubuntu 22.04
+- claim class: engineering evidence only, not publication-grade hardware evidence
+
+## Results
+
+| Vertices | Edges | `DynamicGraph` | `CsrGraph` | Teseo adapter | Exact |
+| ---: | ---: | ---: | ---: | ---: | :---: |
+| 8,192 | 32,768 | 120.434 µs | 57.988 µs | 4,341.401 µs | yes |
+| 32,768 | 131,072 | 500.383 µs | 234.284 µs | 21,854.866 µs | yes |
+
+On these two hosted storage-swap cases, read-optimised CSR is about **2.08×–2.14× faster** than VeloGraphX `DynamicGraph` for full BFS recomputation. With the same VeloGraphX BFS algorithm, `DynamicGraph` traversal is about **36.0×–43.7× faster** than traversal through the Teseo iterator adapter.
+
+These numbers are **not a system-level claim that VeloGraphX is 36×–44× faster than Teseo**. They measure one fixed BFS implementation through each storage interface. Teseo's own algorithms, tuning, update throughput, concurrency and other system capabilities are outside this experiment. The result is useful specifically because the algorithm is held constant while storage is changed.
+
+## Reproduction
+
+```bash
+gh workflow run external-teseo-storage.yml --ref main
+```
+
+Validated run: `33475389747`. Artifact: `9787994251` (`velographx-teseo-storage-swap`). The workflow pins the external commit, builds Teseo from source, runs the full VeloGraphX test suite first, executes both storage-swap sizes, requires exact output equality, and records immutable experiment metadata.
+
+Sortledton remains a useful additional independent storage backend for future replication; it is not needed to establish that the current graph-access contract supports a real external representation.

--- a/include/velographx/graph_access.hpp
+++ b/include/velographx/graph_access.hpp
@@ -10,17 +10,6 @@
 
 namespace velographx {
 
-template <class Graph>
-concept ReadableGraph = requires(const Graph& graph, VertexId vertex) {
-  { graph.vertex_count() } -> std::convertible_to<std::size_t>;
-  { graph.directed() } -> std::convertible_to<bool>;
-};
-
-template <class Graph>
-concept MutableGraph = ReadableGraph<Graph> && requires(Graph& graph) {
-  { graph.version() } -> std::convertible_to<std::uint64_t>;
-};
-
 namespace graph_access_detail {
 
 template <class T>
@@ -32,24 +21,84 @@ template <class T>
   }
 }
 
+template <class Graph>
+concept MemberVertexCount = requires(const Graph& graph) {
+  { graph.vertex_count() } -> std::convertible_to<std::size_t>;
+};
+
+template <class Graph>
+concept AdlVertexCount = requires(const Graph& graph) {
+  { vx_vertex_count(graph) } -> std::convertible_to<std::size_t>;
+};
+
+template <class Graph>
+concept MemberDirected = requires(const Graph& graph) {
+  { graph.directed() } -> std::convertible_to<bool>;
+};
+
+template <class Graph>
+concept AdlDirected = requires(const Graph& graph) {
+  { vx_is_directed(graph) } -> std::convertible_to<bool>;
+};
+
+template <class Graph>
+concept MemberVersion = requires(const Graph& graph) {
+  { graph.version() } -> std::convertible_to<std::uint64_t>;
+};
+
+template <class Graph>
+concept AdlVersion = requires(const Graph& graph) {
+  { vx_version(graph) } -> std::convertible_to<std::uint64_t>;
+};
+
 }  // namespace graph_access_detail
 
+template <class Graph>
+concept ReadableGraph =
+    (graph_access_detail::MemberVertexCount<Graph> || graph_access_detail::AdlVertexCount<Graph>) &&
+    (graph_access_detail::MemberDirected<Graph> || graph_access_detail::AdlDirected<Graph>);
+
+template <class Graph>
+concept MutableGraph = ReadableGraph<Graph> &&
+    (graph_access_detail::MemberVersion<Graph> || graph_access_detail::AdlVersion<Graph>);
+
 template <ReadableGraph Graph>
-[[nodiscard]] constexpr std::size_t vertex_count(const Graph& graph) noexcept(noexcept(graph.vertex_count())) {
-  return static_cast<std::size_t>(graph.vertex_count());
+[[nodiscard]] constexpr std::size_t vertex_count(const Graph& graph) {
+  if constexpr (graph_access_detail::MemberVertexCount<Graph>) {
+    return static_cast<std::size_t>(graph.vertex_count());
+  } else {
+    return static_cast<std::size_t>(vx_vertex_count(graph));
+  }
 }
 
 template <ReadableGraph Graph>
-[[nodiscard]] constexpr bool is_directed(const Graph& graph) noexcept(noexcept(graph.directed())) {
-  return static_cast<bool>(graph.directed());
+[[nodiscard]] constexpr bool is_directed(const Graph& graph) {
+  if constexpr (graph_access_detail::MemberDirected<Graph>) {
+    return static_cast<bool>(graph.directed());
+  } else {
+    return static_cast<bool>(vx_is_directed(graph));
+  }
+}
+
+template <MutableGraph Graph>
+[[nodiscard]] constexpr std::uint64_t graph_version(const Graph& graph) {
+  if constexpr (graph_access_detail::MemberVersion<Graph>) {
+    return static_cast<std::uint64_t>(graph.version());
+  } else {
+    return static_cast<std::uint64_t>(vx_version(graph));
+  }
 }
 
 template <ReadableGraph Graph, class Fn>
 void for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
   if constexpr (requires { graph.for_each_neighbor(u, std::forward<Fn>(fn)); }) {
     graph.for_each_neighbor(u, std::forward<Fn>(fn));
+  } else if constexpr (requires { vx_for_each_neighbor(graph, u, std::forward<Fn>(fn)); }) {
+    vx_for_each_neighbor(graph, u, std::forward<Fn>(fn));
   } else {
-    for (const auto& neighbor : graph.neighbors(u)) fn(graph_access_detail::neighbor_target(neighbor));
+    for (const auto& neighbor : graph.neighbors(u)) {
+      fn(graph_access_detail::neighbor_target(neighbor));
+    }
   }
 }
 
@@ -57,8 +106,12 @@ template <ReadableGraph Graph, class Fn>
 void for_each_in_neighbor(const Graph& graph, VertexId v, Fn&& fn) {
   if constexpr (requires { graph.for_each_in_neighbor(v, std::forward<Fn>(fn)); }) {
     graph.for_each_in_neighbor(v, std::forward<Fn>(fn));
+  } else if constexpr (requires { vx_for_each_in_neighbor(graph, v, std::forward<Fn>(fn)); }) {
+    vx_for_each_in_neighbor(graph, v, std::forward<Fn>(fn));
   } else if constexpr (requires { graph.in_neighbors(v); }) {
-    for (const auto& neighbor : graph.in_neighbors(v)) fn(graph_access_detail::neighbor_target(neighbor));
+    for (const auto& neighbor : graph.in_neighbors(v)) {
+      fn(graph_access_detail::neighbor_target(neighbor));
+    }
   } else {
     for (VertexId u = 0; u < vertex_count(graph); ++u) {
       for_each_neighbor(graph, u, [&](VertexId dst) {
@@ -72,6 +125,8 @@ template <ReadableGraph Graph>
 [[nodiscard]] std::size_t neighbor_count(const Graph& graph, VertexId u) {
   if constexpr (requires { graph.degree(u); }) {
     return static_cast<std::size_t>(graph.degree(u));
+  } else if constexpr (requires { vx_neighbor_count(graph, u); }) {
+    return static_cast<std::size_t>(vx_neighbor_count(graph, u));
   } else {
     std::size_t count = 0;
     for_each_neighbor(graph, u, [&](VertexId) { ++count; });
@@ -83,6 +138,8 @@ template <ReadableGraph Graph>
 [[nodiscard]] bool has_edge(const Graph& graph, VertexId u, VertexId v) {
   if constexpr (requires { graph.has_edge(u, v); }) {
     return graph.has_edge(u, v);
+  } else if constexpr (requires { vx_has_edge(graph, u, v); }) {
+    return vx_has_edge(graph, u, v);
   } else {
     bool found = false;
     for_each_neighbor(graph, u, [&](VertexId dst) { found = found || dst == v; });
@@ -92,7 +149,11 @@ template <ReadableGraph Graph>
 
 template <class Graph, class Batch>
 void apply_updates(Graph& graph, const Batch& batch) {
-  graph.apply(batch);
+  if constexpr (requires { graph.apply(batch); }) {
+    graph.apply(batch);
+  } else {
+    vx_apply_updates(graph, batch);
+  }
 }
 
 }  // namespace velographx

--- a/include/velographx/incremental/bfs.hpp
+++ b/include/velographx/incremental/bfs.hpp
@@ -31,13 +31,13 @@ class BasicIncrementalBFS {
     last_used_full_recompute_ = false;
     if (batch.empty()) return;
 
-    ensure_workspace(g_.vertex_count());
+    ensure_workspace(vertex_count(g_));
     prepare_batch_workspace(batch.updates.size());
 
     for (auto it = batch.updates.rbegin(); it != batch.updates.rend(); ++it) {
       auto u = it->src;
       auto v = it->dst;
-      if (!g_.directed() && v < u) std::swap(u, v);
+      if (!is_directed(g_) && v < u) std::swap(u, v);
       const auto key = edge_key(u, v);
       if (!seen_final_updates_.insert(key)) continue;
       if (it->add) {
@@ -48,13 +48,13 @@ class BasicIncrementalBFS {
       }
     }
 
-    deletion_candidates_.reserve(final_deletions_.size() * (g_.directed() ? 1 : 2));
+    deletion_candidates_.reserve(final_deletions_.size() * (is_directed(g_) ? 1 : 2));
     existing_deletions_.reserve(final_deletions_.size());
     for (const auto& [u, v] : final_deletions_) {
-      if (!g_.has_edge(u, v)) continue;
+      if (!has_edge(g_, u, v)) continue;
       existing_deletions_.emplace_back(u, v);
       if (is_shortest_parent(u, v)) deletion_candidates_.push_back(v);
-      if (!g_.directed() && is_shortest_parent(v, u)) deletion_candidates_.push_back(u);
+      if (!is_directed(g_) && is_shortest_parent(v, u)) deletion_candidates_.push_back(u);
     }
     std::sort(deletion_candidates_.begin(), deletion_candidates_.end());
     deletion_candidates_.erase(std::unique(deletion_candidates_.begin(), deletion_candidates_.end()),
@@ -62,15 +62,15 @@ class BasicIncrementalBFS {
     last_deletion_candidates_ = deletion_candidates_.size();
 
     affected_vertices_.reserve(std::min<std::size_t>(deletion_candidates_.size() * 2 + 8,
-                                                      g_.vertex_count()));
+                                                      vertex_count(g_)));
     bool fallback_needed = false;
     if (!deletion_candidates_.empty()) {
       fallback_needed = !compute_affected_prebatch(existing_deletions_, final_deletion_keys_);
     }
 
-    g_.apply(batch);
-    if (dist_.size() < g_.vertex_count()) dist_.resize(g_.vertex_count(), unreachable);
-    ensure_workspace(g_.vertex_count());
+    apply_updates(g_, batch);
+    if (dist_.size() < vertex_count(g_)) dist_.resize(vertex_count(g_), unreachable);
+    ensure_workspace(vertex_count(g_));
 
     if (fallback_needed) {
       clear_workspace();
@@ -90,24 +90,24 @@ class BasicIncrementalBFS {
     bfs_queue_.clear();
     for (const auto& [u, v] : final_additions_) {
       relax_edge(u, v, bfs_queue_);
-      if (!g_.directed()) relax_edge(v, u, bfs_queue_);
+      if (!is_directed(g_)) relax_edge(v, u, bfs_queue_);
     }
     propagate_decreases(bfs_queue_);
     clear_workspace();
   }
 
   void recompute() {
-    dist_.assign(g_.vertex_count(), unreachable);
-    ensure_workspace(g_.vertex_count());
-    if (source_ >= g_.vertex_count()) return;
+    dist_.assign(vertex_count(g_), unreachable);
+    ensure_workspace(vertex_count(g_));
+    if (source_ >= vertex_count(g_)) return;
     bfs_queue_.clear();
-    bfs_queue_.reserve(std::max(bfs_queue_.capacity(), g_.vertex_count()));
+    bfs_queue_.reserve(std::max(bfs_queue_.capacity(), vertex_count(g_)));
     dist_[source_] = 0;
     bfs_queue_.push_back(source_);
     std::size_t head = 0;
     while (head < bfs_queue_.size()) {
       const auto u = bfs_queue_[head++];
-      g_.for_each_neighbor(u, [&](VertexId v) {
+      for_each_neighbor(g_, u, [&](VertexId v) {
         if (dist_[v] == unreachable) {
           dist_[v] = dist_[u] + 1;
           bfs_queue_.push_back(v);
@@ -173,7 +173,7 @@ class BasicIncrementalBFS {
   };
 
   [[nodiscard]] std::uint64_t edge_key(VertexId u, VertexId v) const noexcept {
-    if (!g_.directed() && v < u) std::swap(u, v);
+    if (!is_directed(g_) && v < u) std::swap(u, v);
     return (static_cast<std::uint64_t>(u) << 32) | static_cast<std::uint64_t>(v);
   }
 
@@ -209,7 +209,7 @@ class BasicIncrementalBFS {
     if (v >= dist_.size() || v == source_ || dist_[v] == unreachable) return 0;
     if (shortest_parent_count_[v] != 0) return shortest_parent_count_[v];
     std::uint32_t count = 0;
-    g_.for_each_in_neighbor(v, [&](VertexId p) {
+    for_each_in_neighbor(g_, v, [&](VertexId p) {
       if (is_shortest_parent(p, v)) ++count;
     });
     shortest_parent_count_[v] = count;
@@ -220,8 +220,8 @@ class BasicIncrementalBFS {
       const std::vector<std::pair<VertexId, VertexId>>& existing_deletions,
       const ReusableKeySet& final_deletion_keys) {
     const auto fallback_limit = std::max<std::size_t>(
-        1, static_cast<std::size_t>(static_cast<double>(g_.vertex_count()) * deletion_fallback_fraction_));
-    invalidate_.reserve(std::min<std::size_t>(existing_deletions.size() * 2 + 8, g_.vertex_count()));
+        1, static_cast<std::size_t>(static_cast<double>(vertex_count(g_)) * deletion_fallback_fraction_));
+    invalidate_.reserve(std::min<std::size_t>(existing_deletions.size() * 2 + 8, vertex_count(g_)));
 
     auto record_parent_loss = [&](VertexId v) {
       if (v >= dist_.size() || v == source_ || dist_[v] == unreachable || affected_[v]) return;
@@ -238,7 +238,7 @@ class BasicIncrementalBFS {
 
     for (const auto& [u, v] : existing_deletions) {
       if (is_shortest_parent(u, v)) record_parent_loss(v);
-      if (!g_.directed() && is_shortest_parent(v, u)) record_parent_loss(u);
+      if (!is_directed(g_) && is_shortest_parent(v, u)) record_parent_loss(u);
     }
 
     std::size_t head = 0;
@@ -246,7 +246,7 @@ class BasicIncrementalBFS {
       if (last_affected_vertices_ > fallback_limit) return false;
       const auto u = invalidate_[head++];
       if (u >= dist_.size() || dist_[u] == unreachable) continue;
-      g_.for_each_neighbor(u, [&](VertexId v) {
+      for_each_neighbor(g_, u, [&](VertexId v) {
         if (v >= dist_.size() || dist_[v] != dist_[u] + 1) return;
         if (final_deletion_keys.contains(edge_key(u, v))) return;
         record_parent_loss(v);
@@ -257,7 +257,7 @@ class BasicIncrementalBFS {
 
   [[nodiscard]] std::uint32_t best_boundary_distance(VertexId v) const {
     std::uint32_t best = unreachable;
-    g_.for_each_in_neighbor(v, [&](VertexId p) {
+    for_each_in_neighbor(g_, v, [&](VertexId p) {
       if (p >= dist_.size() || p >= affected_.size() || affected_[p] || dist_[p] == unreachable) return;
       const auto candidate = dist_[p] + 1;
       if (candidate < best) best = candidate;
@@ -290,7 +290,7 @@ class BasicIncrementalBFS {
       const auto [du, u] = repair_heap_.back();
       repair_heap_.pop_back();
       if (u >= dist_.size() || du != dist_[u]) continue;
-      g_.for_each_neighbor(u, [&](VertexId v) {
+      for_each_neighbor(g_, u, [&](VertexId v) {
         if (v >= affected_.size() || !affected_[v]) return;
         const auto candidate = du + 1;
         if (candidate < dist_[v]) {
@@ -334,7 +334,7 @@ class BasicIncrementalBFS {
     while (head < q.size()) {
       const auto u = q[head++];
       if (dist_[u] == unreachable) continue;
-      g_.for_each_neighbor(u, [&](VertexId v) {
+      for_each_neighbor(g_, u, [&](VertexId v) {
         if (dist_[u] + 1 < dist_[v]) {
           dist_[v] = dist_[u] + 1;
           q.push_back(v);

--- a/tests/test_graph_access_adl.cpp
+++ b/tests/test_graph_access_adl.cpp
@@ -1,0 +1,92 @@
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
+#include "velographx/incremental/bfs.hpp"
+#include "velographx/incremental/sssp.hpp"
+#include "velographx/types.hpp"
+
+namespace foreign_graph {
+
+using velographx::UpdateBatch;
+using velographx::VertexId;
+
+// Deliberately exposes no VeloGraphX-named member API. All adaptation is by ADL.
+struct Graph {
+  std::vector<std::vector<VertexId>> out;
+  std::uint64_t revision{0};
+};
+
+std::size_t vx_vertex_count(const Graph& g) { return g.out.size(); }
+bool vx_is_directed(const Graph&) { return false; }
+std::uint64_t vx_version(const Graph& g) { return g.revision; }
+
+template <class Fn>
+void vx_for_each_neighbor(const Graph& g, VertexId u, Fn&& fn) {
+  if (u >= g.out.size()) return;
+  for (auto v : g.out[u]) fn(v);
+}
+
+template <class Fn>
+void vx_for_each_in_neighbor(const Graph& g, VertexId v, Fn&& fn) {
+  vx_for_each_neighbor(g, v, std::forward<Fn>(fn));
+}
+
+bool vx_has_edge(const Graph& g, VertexId u, VertexId v) {
+  if (u >= g.out.size()) return false;
+  return std::binary_search(g.out[u].begin(), g.out[u].end(), v);
+}
+
+void vx_apply_updates(Graph& g, const UpdateBatch& batch) {
+  auto ensure = [&](VertexId v) {
+    if (v >= g.out.size()) g.out.resize(static_cast<std::size_t>(v) + 1);
+  };
+  auto change = [&](VertexId u, VertexId v, bool add) {
+    ensure(std::max(u, v));
+    auto& row = g.out[u];
+    auto it = std::lower_bound(row.begin(), row.end(), v);
+    if (add) {
+      if (it == row.end() || *it != v) row.insert(it, v);
+    } else if (it != row.end() && *it == v) {
+      row.erase(it);
+    }
+  };
+  for (const auto& e : batch.updates) {
+    change(e.src, e.dst, e.add);
+    if (e.src != e.dst) change(e.dst, e.src, e.add);
+  }
+  ++g.revision;
+}
+
+}  // namespace foreign_graph
+
+int main() {
+  using namespace velographx;
+  foreign_graph::Graph graph{{{1}, {0, 2}, {1, 3}, {2}, {}}};
+
+  static_assert(ReadableGraph<foreign_graph::Graph>);
+  static_assert(MutableGraph<foreign_graph::Graph>);
+
+  BasicIncrementalBFS<foreign_graph::Graph> bfs(graph, 0);
+  assert((bfs.distances() == std::vector<std::uint32_t>{0, 1, 2, 3, BasicIncrementalBFS<foreign_graph::Graph>::unreachable}));
+
+  BasicIncrementalSSSP<foreign_graph::Graph> sssp(graph, 0);
+  assert(sssp.distances()[3] == 3);
+
+  UpdateBatch add;
+  add.add(0, 4);
+  bfs.apply(add);
+  sssp.apply(add);
+  assert(bfs.distances()[4] == 1);
+  assert(sssp.distances()[4] == 1);
+
+  UpdateBatch remove;
+  remove.remove(1, 2);
+  bfs.apply(remove);
+  sssp.apply(remove);
+  assert(bfs.distances()[2] == BasicIncrementalBFS<foreign_graph::Graph>::unreachable);
+  assert(sssp.distances()[2] == incremental_detail::kDijkstraInf);
+
+  return 0;
+}


### PR DESCRIPTION
Completes the two remaining storage-abstraction items from the external Boost.Graph feedback.

- makes the C++20 graph-access layer non-intrusive through ADL `vx_*` customisation hooks
- routes `BasicIncrementalBFS` fully through the generic graph-access contract
- adds an ADL-only foreign graph regression test; full CTest count is now 29
- adds a pinned `cwida/teseo` adapter and same-algorithm `BasicIncrementalBFS::recompute()` storage-swap workflow
- records exact hosted results and explicitly separates storage-interface evidence from system-level Teseo claims
- updates graph-abstraction documentation and README reproduction/limitations

Validated branch evidence: run `33475389747`, 29/29 CTest passed, Teseo build/benchmark/validation passed, artifact `9787994251`.

Observed medians (5 reps, construction excluded):
- 8,192 vertices / 32,768 edges: DynamicGraph 120.434 µs, CSR 57.988 µs, Teseo adapter 4,341.401 µs, exact
- 32,768 vertices / 131,072 edges: DynamicGraph 500.383 µs, CSR 234.284 µs, Teseo adapter 21,854.866 µs, exact

These are same-algorithm storage-interface measurements, not a general performance claim against Teseo's native algorithms.