### PR TITLE
Add Sortledton adapter and harden canonical GAP evidence

### DIFF
--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -81,7 +81,7 @@ jobs:
               ],
               'validated_block_size': 1024,
               'property_size': 8,
-              'read_transaction_lifecycle': 'adapter uses Sortledton reusable SnapshotTransaction overload without modifying TransactionManager',
+              'read_transaction_lifecycle': 'adapter uses an epoch-pinned quiescent SnapshotTransaction read view; TransactionManager is unmodified',
               'toolchain_consistency': 'VeloGraphX, Sortledton and adapter all built with GCC/G++ 10',
               'compiler': gcc,
           }, indent=2, sort_keys=True) + '\n')
@@ -170,7 +170,7 @@ jobs:
               'build_compatibility_patch_sha256': hashlib.sha256(patch.read_bytes()).hexdigest(),
               'sortledton_block_size': 1024,
               'property_size': 8,
-              'read_transaction_lifecycle': 'adapter uses Sortledton reusable SnapshotTransaction overload',
+              'read_transaction_lifecycle': 'adapter uses an epoch-pinned quiescent SnapshotTransaction read view',
               'toolchain_consistency': 'VeloGraphX, Sortledton and adapter all GCC/G++ 10',
               'compiler': subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0],
               'platform': platform.platform(),

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 45
     env:
       SORTLEDTON_SHA: 6eb638f3ad38f8a10a127e7e118528f4c8d07a6e
+      SORTLEDTON_BUILD: external/sortledton/microbenchmark/build
     steps:
       - uses: actions/checkout@v4
 
@@ -40,22 +41,26 @@ jobs:
           git clone https://gitlab.db.in.tum.de/per.fuchs/sortledton.git external/sortledton
           git -C external/sortledton checkout "$SORTLEDTON_SHA"
           test "$(git -C external/sortledton rev-parse HEAD)" = "$SORTLEDTON_SHA"
+          test -f external/sortledton/microbenchmark/CMakeLists.txt
 
       - name: Build Sortledton
         run: |
-          cmake -S external/sortledton -B external/sortledton/build -DCMAKE_BUILD_TYPE=Release
-          cmake --build external/sortledton/build --parallel 2
-          test -f external/sortledton/build/libsortledton.a
+          cmake -S external/sortledton/microbenchmark -B "$SORTLEDTON_BUILD" -DCMAKE_BUILD_TYPE=Release
+          cmake --build "$SORTLEDTON_BUILD" --parallel 2
+          test -f "$SORTLEDTON_BUILD/libsortledton.a"
 
       - name: Compile same-algorithm Sortledton storage benchmark
         run: |
           c++ -O3 -DNDEBUG -std=c++20 -fopenmp \
             -Iinclude \
-            -Iexternal/sortledton/include \
-            -Iexternal/sortledton \
+            -Iexternal/sortledton/microbenchmark \
+            -Iexternal/sortledton/microbenchmark/include \
+            -Iexternal/sortledton/microbenchmark/data-structure \
+            -Iexternal/sortledton/microbenchmark/data-structure/versioning \
+            -Iexternal/sortledton/microbenchmark/data-structures \
             benchmarks/external_sortledton_storage_bfs.cpp \
             build/libvelographx.a \
-            external/sortledton/build/libsortledton.a \
+            "$SORTLEDTON_BUILD/libsortledton.a" \
             -ltbb -lnuma -lpthread \
             -o build/velographx_external_sortledton_storage_bfs
 

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -48,29 +48,58 @@ jobs:
           test "$(git -C external/sortledton rev-parse HEAD)" = "$SORTLEDTON_SHA"
           test -f external/sortledton/CMakeLists.txt
 
-      - name: Record pinned source and apply validation-only compatibility guard
+      - name: Record pinned source and apply compatibility guards
         run: |
           mkdir -p artifacts/sortledton
           cp external/sortledton/CMakeLists.txt artifacts/sortledton/upstream-CMakeLists.txt
           cp external/sortledton/data-structure/VersioningBlockedSkipListAdjacencyList.cpp artifacts/sortledton/upstream-VersioningBlockedSkipListAdjacencyList.cpp
+          cp external/sortledton/data-structure/TransactionManager.cpp artifacts/sortledton/upstream-TransactionManager.cpp
           git -C external/sortledton diff --exit-code
           python - <<'PY'
           import json, subprocess
           from pathlib import Path
-          p = Path('external/sortledton/data-structure/VersioningBlockedSkipListAdjacencyList.cpp')
-          text = p.read_text()
+
+          storage = Path('external/sortledton/data-structure/VersioningBlockedSkipListAdjacencyList.cpp')
+          text = storage.read_text()
           old = '  if (round_up_power_of_two(block_size) != block_size) {\n    throw ConfigurationError("Block size needs to be a power of two.");\n  }'
           new = '  if (block_size == 0 || (block_size & (block_size - 1)) != 0) {\n    throw ConfigurationError("Block size needs to be a power of two.");\n  }'
           assert old in text
-          p.write_text(text.replace(old, new, 1))
+          storage.write_text(text.replace(old, new, 1))
+
+          tm = Path('external/sortledton/data-structure/TransactionManager.cpp')
+          text = tm.read_text()
+          old = '''SnapshotTransaction TransactionManager::getSnapshotTransaction(VersionedTopologyInterface* ti, bool write_only, bool analytics) {
+  
+  return SnapshotTransaction(this, write_only, ti, analytics);
+}'''
+          new = '''SnapshotTransaction TransactionManager::getSnapshotTransaction(VersionedTopologyInterface* ti, bool write_only, bool analytics) {
+  if (write_only) {
+    return SnapshotTransaction(this, true, ti, analytics);
+  }
+  SnapshotTransaction tx(this, true, ti, analytics);
+  tx.clear(false);
+  tx.set_read_timestamp(draw_timestamp(false));
+  return tx;
+}'''
+          assert old in text
+          tm.write_text(text.replace(old, new, 1))
+
           with open('artifacts/sortledton/build-compatibility.patch','w') as out:
-              subprocess.run(['git','-C','external/sortledton','diff','--','data-structure/VersioningBlockedSkipListAdjacencyList.cpp'], check=True, stdout=out)
+              subprocess.run([
+                  'git','-C','external/sortledton','diff','--',
+                  'data-structure/VersioningBlockedSkipListAdjacencyList.cpp',
+                  'data-structure/TransactionManager.cpp'
+              ], check=True, stdout=out)
+
           gcc = subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0]
           Path('artifacts/sortledton/build-compatibility.json').write_text(json.dumps({
-              'scope': 'constructor-validation-only',
+              'scope': 'constructor-validation-and-read-transaction-lifecycle',
               'sortledton_commit': '6eb638f3ad38f8a10a127e7e118528f4c8d07a6e',
               'graph_storage_semantics_changed': False,
-              'compatibility_adjustment': 'replace round_up_power_of_two equality guard with the equivalent direct nonzero power-of-two bit test',
+              'compatibility_adjustments': [
+                  'replace round_up_power_of_two equality guard with the equivalent direct nonzero power-of-two bit test',
+                  'initialize fresh read transactions with the same clear(false)+draw_timestamp(false) lifecycle used by Sortledton reusable transactions',
+              ],
               'validated_block_size': 1024,
               'property_size': 8,
               'toolchain_consistency': 'VeloGraphX, Sortledton and adapter all built with GCC/G++ 10',
@@ -157,7 +186,7 @@ jobs:
               'backend': 'Sortledton',
               'sortledton_commit': subprocess.check_output(['git','-C','external/sortledton','rev-parse','HEAD'], text=True).strip(),
               'pin_source': 'GFE Driver SIGMOD 2025 README paper-evaluated Sortledton revision',
-              'build_compatibility_scope': 'constructor validation expression only; graph storage/update semantics unchanged',
+              'build_compatibility_scope': 'constructor validation and fresh-read transaction lifecycle only; graph storage/update semantics unchanged',
               'build_compatibility_patch_sha256': hashlib.sha256(patch.read_bytes()).hexdigest(),
               'sortledton_block_size': 1024,
               'property_size': 8,

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -86,8 +86,17 @@ jobs:
 
       - name: Run portability and incremental correctness campaign
         run: |
-          build/velographx_external_sortledton_storage_bfs 2048 | tee artifacts/sortledton/sortledton-2048.json
-          build/velographx_external_sortledton_storage_bfs 8192 | tee artifacts/sortledton/sortledton-8192.json
+          set -o pipefail
+          build/velographx_external_sortledton_storage_bfs 2048 2>&1 | tee artifacts/sortledton/sortledton-2048.log
+          build/velographx_external_sortledton_storage_bfs 8192 2>&1 | tee artifacts/sortledton/sortledton-8192.log
+          python - <<'PY'
+          from pathlib import Path
+          for n in (2048, 8192):
+              lines = Path(f'artifacts/sortledton/sortledton-{n}.log').read_text().splitlines()
+              json_lines = [line for line in lines if line.startswith('{')]
+              assert len(json_lines) == 1, (n, lines[-20:])
+              Path(f'artifacts/sortledton/sortledton-{n}.json').write_text(json_lines[0] + '\n')
+          PY
 
       - name: Validate exactness and claim gates
         run: |

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -1,0 +1,123 @@
+name: External Sortledton Storage Evidence
+
+on:
+  push:
+    paths:
+      - '.github/workflows/external-sortledton-storage.yml'
+      - 'benchmarks/external_sortledton_storage_bfs.cpp'
+      - 'include/velographx/graph_access.hpp'
+      - 'include/velographx/incremental/bfs.hpp'
+  pull_request:
+    paths:
+      - '.github/workflows/external-sortledton-storage.yml'
+      - 'benchmarks/external_sortledton_storage_bfs.cpp'
+      - 'include/velographx/graph_access.hpp'
+      - 'include/velographx/incremental/bfs.hpp'
+  workflow_dispatch:
+
+jobs:
+  sortledton-storage-adapter:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    env:
+      SORTLEDTON_SHA: 6eb638f3ad38f8a10a127e7e118528f4c8d07a6e
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build libtbb-dev libnuma-dev
+
+      - name: Build VeloGraphX library and tests
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DVELOGRAPHX_BUILD_TESTS=ON -DVELOGRAPHX_BUILD_BENCHMARKS=OFF
+          cmake --build build --parallel 2
+          ctest --test-dir build --output-on-failure
+
+      - name: Clone immutable Sortledton revision
+        run: |
+          git clone https://gitlab.db.in.tum.de/per.fuchs/sortledton.git external/sortledton
+          git -C external/sortledton checkout "$SORTLEDTON_SHA"
+          test "$(git -C external/sortledton rev-parse HEAD)" = "$SORTLEDTON_SHA"
+
+      - name: Build Sortledton
+        run: |
+          cmake -S external/sortledton -B external/sortledton/build -DCMAKE_BUILD_TYPE=Release
+          cmake --build external/sortledton/build --parallel 2
+          test -f external/sortledton/build/libsortledton.a
+
+      - name: Compile same-algorithm Sortledton storage benchmark
+        run: |
+          c++ -O3 -DNDEBUG -std=c++20 -fopenmp \
+            -Iinclude \
+            -Iexternal/sortledton/include \
+            -Iexternal/sortledton \
+            benchmarks/external_sortledton_storage_bfs.cpp \
+            build/libvelographx.a \
+            external/sortledton/build/libsortledton.a \
+            -ltbb -lnuma -lpthread \
+            -o build/velographx_external_sortledton_storage_bfs
+
+      - name: Run portability and incremental correctness campaign
+        run: |
+          mkdir -p artifacts/sortledton
+          build/velographx_external_sortledton_storage_bfs 2048 | tee artifacts/sortledton/sortledton-2048.json
+          build/velographx_external_sortledton_storage_bfs 8192 | tee artifacts/sortledton/sortledton-8192.json
+
+      - name: Validate exactness and claim gates
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          for path in sorted(Path('artifacts/sortledton').glob('sortledton-*.json')):
+              row = json.loads(path.read_text())
+              assert row['schema_version'] == 1
+              assert row['benchmark'] == 'same-algorithm-storage-bfs'
+              assert row['backend'] == 'sortledton'
+              assert row['algorithm'] == 'BasicIncrementalBFS'
+              assert row['claim_scope'] == 'correctness-and-storage-portability-only'
+              assert row['publication_grade'] is False
+              assert row['repetitions'] == 5
+              assert row['incremental_batches'] == 5
+              assert row['exact'] is True
+              assert row['recompute_exact'] is True
+              assert row['incremental_exact'] is True
+              assert row['dynamic_graph_median_us'] > 0
+              assert row['csr_graph_median_us'] > 0
+              assert row['sortledton_median_us'] > 0
+              assert row['dynamic_incremental_median_us'] > 0
+              assert row['sortledton_incremental_median_us'] > 0
+          PY
+
+      - name: Record immutable provenance
+        run: |
+          python - <<'PY'
+          import json, platform, subprocess
+          from pathlib import Path
+          payload = {
+              'schema_version': 1,
+              'artifact_type': 'velographx-sortledton-storage-adapter',
+              'publication_grade': False,
+              'research_claim': False,
+              'same_algorithm': 'BasicIncrementalBFS',
+              'backend': 'Sortledton',
+              'sortledton_commit': subprocess.check_output(['git','-C','external/sortledton','rev-parse','HEAD'], text=True).strip(),
+              'pin_source': 'GFE Driver SIGMOD 2025 README paper-evaluated Sortledton revision',
+              'compiler': subprocess.check_output(['c++','--version'], text=True).splitlines()[0],
+              'platform': platform.platform(),
+              'runner': 'github-hosted ubuntu-22.04',
+              'correctness_gate': 'full BFS distance-vector equality after recompute and every deterministic mixed insertion/deletion batch',
+              'claim_gate': 'storage portability/correctness evidence only; timings are not publication-grade system comparisons',
+          }
+          assert payload['sortledton_commit'] == '6eb638f3ad38f8a10a127e7e118528f4c8d07a6e'
+          Path('artifacts/sortledton/metadata.json').write_text(json.dumps(payload, indent=2, sort_keys=True) + '\n')
+          PY
+
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: velographx-sortledton-storage-adapter
+          path: artifacts/sortledton
+          retention-days: 30

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -43,38 +43,36 @@ jobs:
           test "$(git -C external/sortledton rev-parse HEAD)" = "$SORTLEDTON_SHA"
           test -f external/sortledton/CMakeLists.txt
 
-      - name: Apply modern-toolchain build-only compatibility patch
+      - name: Record and conditionally adapt legacy TBB build declarations
         run: |
           mkdir -p artifacts/sortledton
+          cp external/sortledton/CMakeLists.txt artifacts/sortledton/upstream-CMakeLists.txt
           git -C external/sortledton diff --exit-code
           python - <<'PY'
+          import json
           from pathlib import Path
           p = Path('external/sortledton/CMakeLists.txt')
           text = p.read_text()
-          replacements = {
-              'find_package(TBB REQUIRED COMPONENTS tbbmalloc tbbmalloc_proxy)': 'find_package(TBB REQUIRED)',
-              'target_link_libraries(sortledton tbb)': 'target_link_libraries(sortledton TBB::tbb)',
-              'target_link_libraries(sortledton_bin tbb)': 'target_link_libraries(sortledton_bin TBB::tbb)',
-          }
-          changed = []
-          for old, new in replacements.items():
+          replacements = [
+              ('find_package(TBB REQUIRED COMPONENTS tbbmalloc tbbmalloc_proxy)', 'find_package(TBB REQUIRED)'),
+              ('target_link_libraries(sortledton tbb)', 'target_link_libraries(sortledton TBB::tbb)'),
+              ('target_link_libraries(sortledton_bin tbb)', 'target_link_libraries(sortledton_bin TBB::tbb)'),
+          ]
+          applied = []
+          for old, new in replacements:
               if old in text:
                   text = text.replace(old, new)
-                  changed.append(old)
-          if not changed:
-              raise SystemExit('expected Sortledton legacy TBB CMake declarations not found')
-          p.write_text(text)
-          Path('artifacts/sortledton/build-compatibility.json').write_text(
-              '{\n'
-              '  "scope": "build-system-only",\n'
-              '  "upstream_source_modified": false,\n'
-              '  "reason": "map legacy TBB CMake declarations to modern imported target; graph/storage source is unchanged",\n'
-              '  "sortledton_commit": "6eb638f3ad38f8a10a127e7e118528f4c8d07a6e"\n'
-              '}\n'
-          )
+                  applied.append({'from': old, 'to': new})
+          if applied:
+              p.write_text(text)
+          Path('artifacts/sortledton/build-compatibility.json').write_text(json.dumps({
+              'scope': 'build-system-only',
+              'sortledton_commit': '6eb638f3ad38f8a10a127e7e118528f4c8d07a6e',
+              'graph_storage_source_changed': False,
+              'cmake_adjustments': applied,
+          }, indent=2, sort_keys=True) + '\n')
           PY
-          git -C external/sortledton diff -- CMakeLists.txt | tee artifacts/sortledton/sortledton-build-compat.patch
-          test -s artifacts/sortledton/sortledton-build-compat.patch
+          git -C external/sortledton diff -- CMakeLists.txt > artifacts/sortledton/sortledton-build-compat.patch || true
 
       - name: Build Sortledton
         run: |
@@ -137,6 +135,7 @@ jobs:
           python - <<'PY'
           import hashlib, json, platform, subprocess
           from pathlib import Path
+          compat = json.loads(Path('artifacts/sortledton/build-compatibility.json').read_text())
           patch = Path('artifacts/sortledton/sortledton-build-compat.patch')
           payload = {
               'schema_version': 2,
@@ -148,7 +147,8 @@ jobs:
               'sortledton_commit': subprocess.check_output(['git','-C','external/sortledton','rev-parse','HEAD'], text=True).strip(),
               'pin_source': 'GFE Driver SIGMOD 2025 README paper-evaluated Sortledton revision',
               'build_compatibility_patch_sha256': hashlib.sha256(patch.read_bytes()).hexdigest(),
-              'build_compatibility_scope': 'CMake/TBB target naming only; no Sortledton graph/storage source changes',
+              'build_compatibility_adjustments': compat['cmake_adjustments'],
+              'build_compatibility_scope': 'build metadata only; no Sortledton graph/storage source changes',
               'compiler': subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0],
               'platform': platform.platform(),
               'runner': 'github-hosted ubuntu-22.04',

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -30,11 +30,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build gcc-10 g++-10 libboost-dev libpapi-dev libsqlite3-dev libtbb-dev libnuma-dev
 
-      - name: Build VeloGraphX library and tests
+      - name: Build VeloGraphX library and tests with GCC 10
         run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DVELOGRAPHX_BUILD_TESTS=ON -DVELOGRAPHX_BUILD_BENCHMARKS=OFF
+          CC=gcc-10 CXX=g++-10 cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=gcc-10 \
+            -DCMAKE_CXX_COMPILER=g++-10 \
+            -DVELOGRAPHX_BUILD_TESTS=ON \
+            -DVELOGRAPHX_BUILD_BENCHMARKS=OFF
           cmake --build build --parallel 2
           ctest --test-dir build --output-on-failure
+          test "$(build/velographx_example >/dev/null 2>&1; g++-10 -dumpfullversion -dumpversion)" = "$(g++-10 -dumpfullversion -dumpversion)"
 
       - name: Clone immutable Sortledton revision
         run: |
@@ -49,13 +55,16 @@ jobs:
           cp external/sortledton/CMakeLists.txt artifacts/sortledton/upstream-CMakeLists.txt
           git -C external/sortledton diff --exit-code
           python - <<'PY'
-          import json
+          import json, subprocess
           from pathlib import Path
+          gcc = subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0]
           Path('artifacts/sortledton/build-compatibility.json').write_text(json.dumps({
               'scope': 'none',
               'sortledton_commit': '6eb638f3ad38f8a10a127e7e118528f4c8d07a6e',
               'graph_storage_source_changed': False,
               'cmake_adjustments': [],
+              'toolchain_consistency': 'VeloGraphX, Sortledton and adapter all built with GCC/G++ 10',
+              'compiler': gcc,
           }, indent=2, sort_keys=True) + '\n')
           Path('artifacts/sortledton/sortledton-build-compat.patch').write_text('')
           PY
@@ -141,6 +150,7 @@ jobs:
               'pin_source': 'GFE Driver SIGMOD 2025 README paper-evaluated Sortledton revision',
               'build_compatibility_adjustments': [],
               'build_compatibility_scope': 'none; pinned upstream source and CMake used unchanged',
+              'toolchain_consistency': 'VeloGraphX, Sortledton and adapter all GCC/G++ 10',
               'linkage_note': 'link Sortledton with its required TBB runtime only; do not interpose tbbmalloc_proxy on the combined VeloGraphX process',
               'compiler': subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0],
               'platform': platform.platform(),

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -81,7 +81,7 @@ jobs:
             benchmarks/external_sortledton_storage_bfs.cpp \
             build/libvelographx.a \
             "$SORTLEDTON_BUILD/libsortledton.a" \
-            -ltbb -ltbbmalloc -ltbbmalloc_proxy -lnuma -lsqlite3 -lpapi -lpthread \
+            -ltbb -lnuma -lsqlite3 -lpapi -lpthread \
             -o build/velographx_external_sortledton_storage_bfs 2>&1 | tee artifacts/sortledton/adapter-compile.log
 
       - name: Run portability and incremental correctness campaign
@@ -141,6 +141,7 @@ jobs:
               'pin_source': 'GFE Driver SIGMOD 2025 README paper-evaluated Sortledton revision',
               'build_compatibility_adjustments': [],
               'build_compatibility_scope': 'none; pinned upstream source and CMake used unchanged',
+              'linkage_note': 'link Sortledton with its required TBB runtime only; do not interpose tbbmalloc_proxy on the combined VeloGraphX process',
               'compiler': subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0],
               'platform': platform.platform(),
               'runner': 'github-hosted ubuntu-22.04',

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build gcc-10 g++-10 libtbb-dev libnuma-dev
+          sudo apt-get install -y cmake ninja-build gcc-10 g++-10 libboost-all-dev libpapi-dev libsqlite3-dev libtbb-dev libnuma-dev
 
       - name: Build VeloGraphX library and tests
         run: |
@@ -43,7 +43,7 @@ jobs:
           test "$(git -C external/sortledton rev-parse HEAD)" = "$SORTLEDTON_SHA"
           test -f external/sortledton/CMakeLists.txt
 
-      - name: Record and conditionally adapt legacy TBB build declarations
+      - name: Record pinned build metadata
         run: |
           mkdir -p artifacts/sortledton
           cp external/sortledton/CMakeLists.txt artifacts/sortledton/upstream-CMakeLists.txt
@@ -51,28 +51,14 @@ jobs:
           python - <<'PY'
           import json
           from pathlib import Path
-          p = Path('external/sortledton/CMakeLists.txt')
-          text = p.read_text()
-          replacements = [
-              ('find_package(TBB REQUIRED COMPONENTS tbbmalloc tbbmalloc_proxy)', 'find_package(TBB REQUIRED)'),
-              ('target_link_libraries(sortledton tbb)', 'target_link_libraries(sortledton TBB::tbb)'),
-              ('target_link_libraries(sortledton_bin tbb)', 'target_link_libraries(sortledton_bin TBB::tbb)'),
-          ]
-          applied = []
-          for old, new in replacements:
-              if old in text:
-                  text = text.replace(old, new)
-                  applied.append({'from': old, 'to': new})
-          if applied:
-              p.write_text(text)
           Path('artifacts/sortledton/build-compatibility.json').write_text(json.dumps({
-              'scope': 'build-system-only',
+              'scope': 'none',
               'sortledton_commit': '6eb638f3ad38f8a10a127e7e118528f4c8d07a6e',
               'graph_storage_source_changed': False,
-              'cmake_adjustments': applied,
+              'cmake_adjustments': [],
           }, indent=2, sort_keys=True) + '\n')
+          Path('artifacts/sortledton/sortledton-build-compat.patch').write_text('')
           PY
-          git -C external/sortledton diff -- CMakeLists.txt > artifacts/sortledton/sortledton-build-compat.patch || true
 
       - name: Build Sortledton
         run: |
@@ -81,7 +67,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=gcc-10 \
             -DCMAKE_CXX_COMPILER=g++-10 2>&1 | tee artifacts/sortledton/configure.log
-          cmake --build "$SORTLEDTON_BUILD" --parallel 2 2>&1 | tee artifacts/sortledton/build.log
+          cmake --build "$SORTLEDTON_BUILD" --target sortledton --parallel 2 2>&1 | tee artifacts/sortledton/build.log
           test -f "$SORTLEDTON_BUILD/libsortledton.a"
 
       - name: Compile same-algorithm Sortledton storage benchmark
@@ -95,7 +81,7 @@ jobs:
             benchmarks/external_sortledton_storage_bfs.cpp \
             build/libvelographx.a \
             "$SORTLEDTON_BUILD/libsortledton.a" \
-            -ltbb -ltbbmalloc -ltbbmalloc_proxy -lnuma -lpthread \
+            -ltbb -ltbbmalloc -ltbbmalloc_proxy -lnuma -lsqlite3 -lpapi -lpthread \
             -o build/velographx_external_sortledton_storage_bfs 2>&1 | tee artifacts/sortledton/adapter-compile.log
 
       - name: Run portability and incremental correctness campaign
@@ -133,10 +119,8 @@ jobs:
       - name: Record immutable provenance
         run: |
           python - <<'PY'
-          import hashlib, json, platform, subprocess
+          import json, platform, subprocess
           from pathlib import Path
-          compat = json.loads(Path('artifacts/sortledton/build-compatibility.json').read_text())
-          patch = Path('artifacts/sortledton/sortledton-build-compat.patch')
           payload = {
               'schema_version': 2,
               'artifact_type': 'velographx-sortledton-storage-adapter',
@@ -146,9 +130,8 @@ jobs:
               'backend': 'Sortledton',
               'sortledton_commit': subprocess.check_output(['git','-C','external/sortledton','rev-parse','HEAD'], text=True).strip(),
               'pin_source': 'GFE Driver SIGMOD 2025 README paper-evaluated Sortledton revision',
-              'build_compatibility_patch_sha256': hashlib.sha256(patch.read_bytes()).hexdigest(),
-              'build_compatibility_adjustments': compat['cmake_adjustments'],
-              'build_compatibility_scope': 'build metadata only; no Sortledton graph/storage source changes',
+              'build_compatibility_adjustments': [],
+              'build_compatibility_scope': 'none; pinned upstream source and CMake used unchanged',
               'compiler': subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0],
               'platform': platform.platform(),
               'runner': 'github-hosted ubuntu-22.04',

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -43,17 +43,52 @@ jobs:
           test "$(git -C external/sortledton rev-parse HEAD)" = "$SORTLEDTON_SHA"
           test -f external/sortledton/CMakeLists.txt
 
+      - name: Apply modern-toolchain build-only compatibility patch
+        run: |
+          mkdir -p artifacts/sortledton
+          git -C external/sortledton diff --exit-code
+          python - <<'PY'
+          from pathlib import Path
+          p = Path('external/sortledton/CMakeLists.txt')
+          text = p.read_text()
+          replacements = {
+              'find_package(TBB REQUIRED COMPONENTS tbbmalloc tbbmalloc_proxy)': 'find_package(TBB REQUIRED)',
+              'target_link_libraries(sortledton tbb)': 'target_link_libraries(sortledton TBB::tbb)',
+              'target_link_libraries(sortledton_bin tbb)': 'target_link_libraries(sortledton_bin TBB::tbb)',
+          }
+          changed = []
+          for old, new in replacements.items():
+              if old in text:
+                  text = text.replace(old, new)
+                  changed.append(old)
+          if not changed:
+              raise SystemExit('expected Sortledton legacy TBB CMake declarations not found')
+          p.write_text(text)
+          Path('artifacts/sortledton/build-compatibility.json').write_text(
+              '{\n'
+              '  "scope": "build-system-only",\n'
+              '  "upstream_source_modified": false,\n'
+              '  "reason": "map legacy TBB CMake declarations to modern imported target; graph/storage source is unchanged",\n'
+              '  "sortledton_commit": "6eb638f3ad38f8a10a127e7e118528f4c8d07a6e"\n'
+              '}\n'
+          )
+          PY
+          git -C external/sortledton diff -- CMakeLists.txt | tee artifacts/sortledton/sortledton-build-compat.patch
+          test -s artifacts/sortledton/sortledton-build-compat.patch
+
       - name: Build Sortledton
         run: |
+          set -o pipefail
           CC=gcc-10 CXX=g++-10 cmake -S external/sortledton -B "$SORTLEDTON_BUILD" \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=gcc-10 \
-            -DCMAKE_CXX_COMPILER=g++-10
-          cmake --build "$SORTLEDTON_BUILD" --parallel 2
+            -DCMAKE_CXX_COMPILER=g++-10 2>&1 | tee artifacts/sortledton/configure.log
+          cmake --build "$SORTLEDTON_BUILD" --parallel 2 2>&1 | tee artifacts/sortledton/build.log
           test -f "$SORTLEDTON_BUILD/libsortledton.a"
 
       - name: Compile same-algorithm Sortledton storage benchmark
         run: |
+          set -o pipefail
           g++-10 -O3 -DNDEBUG -std=c++20 -fopenmp \
             -Iinclude \
             -Iexternal/sortledton \
@@ -63,11 +98,10 @@ jobs:
             build/libvelographx.a \
             "$SORTLEDTON_BUILD/libsortledton.a" \
             -ltbb -ltbbmalloc -ltbbmalloc_proxy -lnuma -lpthread \
-            -o build/velographx_external_sortledton_storage_bfs
+            -o build/velographx_external_sortledton_storage_bfs 2>&1 | tee artifacts/sortledton/adapter-compile.log
 
       - name: Run portability and incremental correctness campaign
         run: |
-          mkdir -p artifacts/sortledton
           build/velographx_external_sortledton_storage_bfs 2048 | tee artifacts/sortledton/sortledton-2048.json
           build/velographx_external_sortledton_storage_bfs 8192 | tee artifacts/sortledton/sortledton-8192.json
 
@@ -76,7 +110,9 @@ jobs:
           python - <<'PY'
           import json
           from pathlib import Path
-          for path in sorted(Path('artifacts/sortledton').glob('sortledton-*.json')):
+          files = sorted(Path('artifacts/sortledton').glob('sortledton-*.json'))
+          assert len(files) == 2
+          for path in files:
               row = json.loads(path.read_text())
               assert row['schema_version'] == 1
               assert row['benchmark'] == 'same-algorithm-storage-bfs'
@@ -99,10 +135,11 @@ jobs:
       - name: Record immutable provenance
         run: |
           python - <<'PY'
-          import json, platform, subprocess
+          import hashlib, json, platform, subprocess
           from pathlib import Path
+          patch = Path('artifacts/sortledton/sortledton-build-compat.patch')
           payload = {
-              'schema_version': 1,
+              'schema_version': 2,
               'artifact_type': 'velographx-sortledton-storage-adapter',
               'publication_grade': False,
               'research_claim': False,
@@ -110,6 +147,8 @@ jobs:
               'backend': 'Sortledton',
               'sortledton_commit': subprocess.check_output(['git','-C','external/sortledton','rev-parse','HEAD'], text=True).strip(),
               'pin_source': 'GFE Driver SIGMOD 2025 README paper-evaluated Sortledton revision',
+              'build_compatibility_patch_sha256': hashlib.sha256(patch.read_bytes()).hexdigest(),
+              'build_compatibility_scope': 'CMake/TBB target naming only; no Sortledton graph/storage source changes',
               'compiler': subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0],
               'platform': platform.platform(),
               'runner': 'github-hosted ubuntu-22.04',
@@ -120,7 +159,7 @@ jobs:
           Path('artifacts/sortledton/metadata.json').write_text(json.dumps(payload, indent=2, sort_keys=True) + '\n')
           PY
 
-      - name: Upload evidence
+      - name: Upload evidence and diagnostics
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -21,14 +21,14 @@ jobs:
     timeout-minutes: 45
     env:
       SORTLEDTON_SHA: 6eb638f3ad38f8a10a127e7e118528f4c8d07a6e
-      SORTLEDTON_BUILD: external/sortledton/microbenchmark/build
+      SORTLEDTON_BUILD: external/sortledton/build
     steps:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libtbb-dev libnuma-dev
+          sudo apt-get install -y cmake ninja-build gcc-10 g++-10 libtbb-dev libnuma-dev
 
       - name: Build VeloGraphX library and tests
         run: |
@@ -41,27 +41,28 @@ jobs:
           git clone https://gitlab.db.in.tum.de/per.fuchs/sortledton.git external/sortledton
           git -C external/sortledton checkout "$SORTLEDTON_SHA"
           test "$(git -C external/sortledton rev-parse HEAD)" = "$SORTLEDTON_SHA"
-          test -f external/sortledton/microbenchmark/CMakeLists.txt
+          test -f external/sortledton/CMakeLists.txt
 
       - name: Build Sortledton
         run: |
-          cmake -S external/sortledton/microbenchmark -B "$SORTLEDTON_BUILD" -DCMAKE_BUILD_TYPE=Release
+          CC=gcc-10 CXX=g++-10 cmake -S external/sortledton -B "$SORTLEDTON_BUILD" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=gcc-10 \
+            -DCMAKE_CXX_COMPILER=g++-10
           cmake --build "$SORTLEDTON_BUILD" --parallel 2
           test -f "$SORTLEDTON_BUILD/libsortledton.a"
 
       - name: Compile same-algorithm Sortledton storage benchmark
         run: |
-          c++ -O3 -DNDEBUG -std=c++20 -fopenmp \
+          g++-10 -O3 -DNDEBUG -std=c++20 -fopenmp \
             -Iinclude \
-            -Iexternal/sortledton/microbenchmark \
-            -Iexternal/sortledton/microbenchmark/include \
-            -Iexternal/sortledton/microbenchmark/data-structure \
-            -Iexternal/sortledton/microbenchmark/data-structure/versioning \
-            -Iexternal/sortledton/microbenchmark/data-structures \
+            -Iexternal/sortledton \
+            -Iexternal/sortledton/data-structure \
+            -Iexternal/sortledton/data-structures \
             benchmarks/external_sortledton_storage_bfs.cpp \
             build/libvelographx.a \
             "$SORTLEDTON_BUILD/libsortledton.a" \
-            -ltbb -lnuma -lpthread \
+            -ltbb -ltbbmalloc -ltbbmalloc_proxy -lnuma -lpthread \
             -o build/velographx_external_sortledton_storage_bfs
 
       - name: Run portability and incremental correctness campaign
@@ -109,7 +110,7 @@ jobs:
               'backend': 'Sortledton',
               'sortledton_commit': subprocess.check_output(['git','-C','external/sortledton','rev-parse','HEAD'], text=True).strip(),
               'pin_source': 'GFE Driver SIGMOD 2025 README paper-evaluated Sortledton revision',
-              'compiler': subprocess.check_output(['c++','--version'], text=True).splitlines()[0],
+              'compiler': subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0],
               'platform': platform.platform(),
               'runner': 'github-hosted ubuntu-22.04',
               'correctness_gate': 'full BFS distance-vector equality after recompute and every deterministic mixed insertion/deletion batch',

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -48,12 +48,11 @@ jobs:
           test "$(git -C external/sortledton rev-parse HEAD)" = "$SORTLEDTON_SHA"
           test -f external/sortledton/CMakeLists.txt
 
-      - name: Record pinned source and apply compatibility guards
+      - name: Record pinned source and apply constructor compatibility guard
         run: |
           mkdir -p artifacts/sortledton
           cp external/sortledton/CMakeLists.txt artifacts/sortledton/upstream-CMakeLists.txt
           cp external/sortledton/data-structure/VersioningBlockedSkipListAdjacencyList.cpp artifacts/sortledton/upstream-VersioningBlockedSkipListAdjacencyList.cpp
-          cp external/sortledton/data-structure/TransactionManager.cpp artifacts/sortledton/upstream-TransactionManager.cpp
           git -C external/sortledton diff --exit-code
           python - <<'PY'
           import json, subprocess
@@ -66,42 +65,23 @@ jobs:
           assert old in text
           storage.write_text(text.replace(old, new, 1))
 
-          tm = Path('external/sortledton/data-structure/TransactionManager.cpp')
-          text = tm.read_text()
-          old = '''SnapshotTransaction TransactionManager::getSnapshotTransaction(VersionedTopologyInterface* ti, bool write_only, bool analytics) {
-  
-  return SnapshotTransaction(this, write_only, ti, analytics);
-}'''
-          new = '''SnapshotTransaction TransactionManager::getSnapshotTransaction(VersionedTopologyInterface* ti, bool write_only, bool analytics) {
-  if (write_only) {
-    return SnapshotTransaction(this, true, ti, analytics);
-  }
-  SnapshotTransaction tx(this, true, ti, analytics);
-  tx.clear(false);
-  tx.set_read_timestamp(draw_timestamp(false));
-  return tx;
-}'''
-          assert old in text
-          tm.write_text(text.replace(old, new, 1))
-
           with open('artifacts/sortledton/build-compatibility.patch','w') as out:
               subprocess.run([
                   'git','-C','external/sortledton','diff','--',
-                  'data-structure/VersioningBlockedSkipListAdjacencyList.cpp',
-                  'data-structure/TransactionManager.cpp'
+                  'data-structure/VersioningBlockedSkipListAdjacencyList.cpp'
               ], check=True, stdout=out)
 
           gcc = subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0]
           Path('artifacts/sortledton/build-compatibility.json').write_text(json.dumps({
-              'scope': 'constructor-validation-and-read-transaction-lifecycle',
+              'scope': 'constructor-validation-only',
               'sortledton_commit': '6eb638f3ad38f8a10a127e7e118528f4c8d07a6e',
               'graph_storage_semantics_changed': False,
               'compatibility_adjustments': [
-                  'replace round_up_power_of_two equality guard with the equivalent direct nonzero power-of-two bit test',
-                  'initialize fresh read transactions with the same clear(false)+draw_timestamp(false) lifecycle used by Sortledton reusable transactions',
+                  'replace round_up_power_of_two equality guard with the equivalent direct nonzero power-of-two bit test'
               ],
               'validated_block_size': 1024,
               'property_size': 8,
+              'read_transaction_lifecycle': 'adapter uses Sortledton reusable SnapshotTransaction overload without modifying TransactionManager',
               'toolchain_consistency': 'VeloGraphX, Sortledton and adapter all built with GCC/G++ 10',
               'compiler': gcc,
           }, indent=2, sort_keys=True) + '\n')
@@ -186,10 +166,11 @@ jobs:
               'backend': 'Sortledton',
               'sortledton_commit': subprocess.check_output(['git','-C','external/sortledton','rev-parse','HEAD'], text=True).strip(),
               'pin_source': 'GFE Driver SIGMOD 2025 README paper-evaluated Sortledton revision',
-              'build_compatibility_scope': 'constructor validation and fresh-read transaction lifecycle only; graph storage/update semantics unchanged',
+              'build_compatibility_scope': 'constructor validation only; graph storage/update and transaction-manager semantics unchanged',
               'build_compatibility_patch_sha256': hashlib.sha256(patch.read_bytes()).hexdigest(),
               'sortledton_block_size': 1024,
               'property_size': 8,
+              'read_transaction_lifecycle': 'adapter uses Sortledton reusable SnapshotTransaction overload',
               'toolchain_consistency': 'VeloGraphX, Sortledton and adapter all GCC/G++ 10',
               'compiler': subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0],
               'platform': platform.platform(),

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build gcc-10 g++-10 libboost-all-dev libpapi-dev libsqlite3-dev libtbb-dev libnuma-dev
+          sudo apt-get install -y cmake ninja-build gcc-10 g++-10 libboost-dev libpapi-dev libsqlite3-dev libtbb-dev libnuma-dev
 
       - name: Build VeloGraphX library and tests
         run: |

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -48,7 +48,7 @@ jobs:
           test "$(git -C external/sortledton rev-parse HEAD)" = "$SORTLEDTON_SHA"
           test -f external/sortledton/CMakeLists.txt
 
-      - name: Record pinned source and add diagnostic-only constructor probe
+      - name: Record pinned source and apply validation-only compatibility guard
         run: |
           mkdir -p artifacts/sortledton
           cp external/sortledton/CMakeLists.txt artifacts/sortledton/upstream-CMakeLists.txt
@@ -59,17 +59,20 @@ jobs:
           from pathlib import Path
           p = Path('external/sortledton/data-structure/VersioningBlockedSkipListAdjacencyList.cpp')
           text = p.read_text()
-          needle = '  cout << "Sortledton.3" << endl;\n'
-          assert needle in text
-          probe = needle + '  cerr << "Sortledton constructor probe: block_size=" << block_size << " rounded=" << round_up_power_of_two(block_size) << " property_size=" << property_size << endl;\n'
-          p.write_text(text.replace(needle, probe, 1))
-          subprocess.run(['git','-C','external/sortledton','diff','--','data-structure/VersioningBlockedSkipListAdjacencyList.cpp'], check=True, stdout=open('artifacts/sortledton/diagnostic-only.patch','w'))
+          old = '  if (round_up_power_of_two(block_size) != block_size) {\n    throw ConfigurationError("Block size needs to be a power of two.");\n  }'
+          new = '  if (block_size == 0 || (block_size & (block_size - 1)) != 0) {\n    throw ConfigurationError("Block size needs to be a power of two.");\n  }'
+          assert old in text
+          p.write_text(text.replace(old, new, 1))
+          with open('artifacts/sortledton/build-compatibility.patch','w') as out:
+              subprocess.run(['git','-C','external/sortledton','diff','--','data-structure/VersioningBlockedSkipListAdjacencyList.cpp'], check=True, stdout=out)
           gcc = subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0]
           Path('artifacts/sortledton/build-compatibility.json').write_text(json.dumps({
-              'scope': 'diagnostic-output-only',
+              'scope': 'constructor-validation-only',
               'sortledton_commit': '6eb638f3ad38f8a10a127e7e118528f4c8d07a6e',
               'graph_storage_semantics_changed': False,
-              'diagnostic_adjustment': 'print constructor block_size, rounded value, and property_size before the existing validation',
+              'compatibility_adjustment': 'replace round_up_power_of_two equality guard with the equivalent direct nonzero power-of-two bit test',
+              'validated_block_size': 1024,
+              'property_size': 8,
               'toolchain_consistency': 'VeloGraphX, Sortledton and adapter all built with GCC/G++ 10',
               'compiler': gcc,
           }, indent=2, sort_keys=True) + '\n')
@@ -142,8 +145,9 @@ jobs:
       - name: Record immutable provenance
         run: |
           python - <<'PY'
-          import json, platform, subprocess
+          import hashlib, json, platform, subprocess
           from pathlib import Path
+          patch = Path('artifacts/sortledton/build-compatibility.patch')
           payload = {
               'schema_version': 2,
               'artifact_type': 'velographx-sortledton-storage-adapter',
@@ -153,7 +157,10 @@ jobs:
               'backend': 'Sortledton',
               'sortledton_commit': subprocess.check_output(['git','-C','external/sortledton','rev-parse','HEAD'], text=True).strip(),
               'pin_source': 'GFE Driver SIGMOD 2025 README paper-evaluated Sortledton revision',
-              'diagnostic_source_adjustment': 'constructor values printed only; no storage semantics changed',
+              'build_compatibility_scope': 'constructor validation expression only; graph storage/update semantics unchanged',
+              'build_compatibility_patch_sha256': hashlib.sha256(patch.read_bytes()).hexdigest(),
+              'sortledton_block_size': 1024,
+              'property_size': 8,
               'toolchain_consistency': 'VeloGraphX, Sortledton and adapter all GCC/G++ 10',
               'compiler': subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0],
               'platform': platform.platform(),

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -81,7 +81,7 @@ jobs:
               ],
               'validated_block_size': 1024,
               'property_size': 8,
-              'read_transaction_lifecycle': 'adapter uses an epoch-pinned quiescent SnapshotTransaction read view; TransactionManager is unmodified',
+              'read_transaction_lifecycle': 'adapter pins quiescent reads to the last successful Sortledton write transaction commit version; TransactionManager is unmodified',
               'toolchain_consistency': 'VeloGraphX, Sortledton and adapter all built with GCC/G++ 10',
               'compiler': gcc,
           }, indent=2, sort_keys=True) + '\n')
@@ -170,7 +170,7 @@ jobs:
               'build_compatibility_patch_sha256': hashlib.sha256(patch.read_bytes()).hexdigest(),
               'sortledton_block_size': 1024,
               'property_size': 8,
-              'read_transaction_lifecycle': 'adapter uses an epoch-pinned quiescent SnapshotTransaction read view',
+              'read_transaction_lifecycle': 'adapter pins quiescent reads to the last successful Sortledton write transaction commit version',
               'toolchain_consistency': 'VeloGraphX, Sortledton and adapter all GCC/G++ 10',
               'compiler': subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0],
               'platform': platform.platform(),

--- a/.github/workflows/external-sortledton-storage.yml
+++ b/.github/workflows/external-sortledton-storage.yml
@@ -40,7 +40,6 @@ jobs:
             -DVELOGRAPHX_BUILD_BENCHMARKS=OFF
           cmake --build build --parallel 2
           ctest --test-dir build --output-on-failure
-          test "$(build/velographx_example >/dev/null 2>&1; g++-10 -dumpfullversion -dumpversion)" = "$(g++-10 -dumpfullversion -dumpversion)"
 
       - name: Clone immutable Sortledton revision
         run: |
@@ -49,24 +48,31 @@ jobs:
           test "$(git -C external/sortledton rev-parse HEAD)" = "$SORTLEDTON_SHA"
           test -f external/sortledton/CMakeLists.txt
 
-      - name: Record pinned build metadata
+      - name: Record pinned source and add diagnostic-only constructor probe
         run: |
           mkdir -p artifacts/sortledton
           cp external/sortledton/CMakeLists.txt artifacts/sortledton/upstream-CMakeLists.txt
+          cp external/sortledton/data-structure/VersioningBlockedSkipListAdjacencyList.cpp artifacts/sortledton/upstream-VersioningBlockedSkipListAdjacencyList.cpp
           git -C external/sortledton diff --exit-code
           python - <<'PY'
           import json, subprocess
           from pathlib import Path
+          p = Path('external/sortledton/data-structure/VersioningBlockedSkipListAdjacencyList.cpp')
+          text = p.read_text()
+          needle = '  cout << "Sortledton.3" << endl;\n'
+          assert needle in text
+          probe = needle + '  cerr << "Sortledton constructor probe: block_size=" << block_size << " rounded=" << round_up_power_of_two(block_size) << " property_size=" << property_size << endl;\n'
+          p.write_text(text.replace(needle, probe, 1))
+          subprocess.run(['git','-C','external/sortledton','diff','--','data-structure/VersioningBlockedSkipListAdjacencyList.cpp'], check=True, stdout=open('artifacts/sortledton/diagnostic-only.patch','w'))
           gcc = subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0]
           Path('artifacts/sortledton/build-compatibility.json').write_text(json.dumps({
-              'scope': 'none',
+              'scope': 'diagnostic-output-only',
               'sortledton_commit': '6eb638f3ad38f8a10a127e7e118528f4c8d07a6e',
-              'graph_storage_source_changed': False,
-              'cmake_adjustments': [],
+              'graph_storage_semantics_changed': False,
+              'diagnostic_adjustment': 'print constructor block_size, rounded value, and property_size before the existing validation',
               'toolchain_consistency': 'VeloGraphX, Sortledton and adapter all built with GCC/G++ 10',
               'compiler': gcc,
           }, indent=2, sort_keys=True) + '\n')
-          Path('artifacts/sortledton/sortledton-build-compat.patch').write_text('')
           PY
 
       - name: Build Sortledton
@@ -86,7 +92,6 @@ jobs:
             -Iinclude \
             -Iexternal/sortledton \
             -Iexternal/sortledton/data-structure \
-            -Iexternal/sortledton/data-structures \
             benchmarks/external_sortledton_storage_bfs.cpp \
             build/libvelographx.a \
             "$SORTLEDTON_BUILD/libsortledton.a" \
@@ -148,10 +153,8 @@ jobs:
               'backend': 'Sortledton',
               'sortledton_commit': subprocess.check_output(['git','-C','external/sortledton','rev-parse','HEAD'], text=True).strip(),
               'pin_source': 'GFE Driver SIGMOD 2025 README paper-evaluated Sortledton revision',
-              'build_compatibility_adjustments': [],
-              'build_compatibility_scope': 'none; pinned upstream source and CMake used unchanged',
+              'diagnostic_source_adjustment': 'constructor values printed only; no storage semantics changed',
               'toolchain_consistency': 'VeloGraphX, Sortledton and adapter all GCC/G++ 10',
-              'linkage_note': 'link Sortledton with its required TBB runtime only; do not interpose tbbmalloc_proxy on the combined VeloGraphX process',
               'compiler': subprocess.check_output(['g++-10','--version'], text=True).splitlines()[0],
               'platform': platform.platform(),
               'runner': 'github-hosted ubuntu-22.04',

--- a/.github/workflows/gap-canonical-multiroot.yml
+++ b/.github/workflows/gap-canonical-multiroot.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Materialise and verify exact canonical dataset
         run: |
           bash tools/materialize_gap_canonical.sh external/gapbs '${{ inputs.dataset }}' artifacts/gap-canonical
-          sha256sum -c "artifacts/gap-canonical/${{ inputs.dataset }}.sha256" --ignore-missing
+          (cd artifacts/gap-canonical && sha256sum -c '${{ inputs.dataset }}.sha256')
 
       - name: Resolve canonical corpus semantics
         id: semantics

--- a/.github/workflows/gap-canonical-multiroot.yml
+++ b/.github/workflows/gap-canonical-multiroot.yml
@@ -24,12 +24,7 @@ on:
         type: choice
         required: true
         default: road
-        options:
-          - twitter
-          - web
-          - road
-          - kron
-          - urand
+        options: [twitter, web, road, kron, urand]
       roots:
         description: Comma-separated source vertices
         type: string
@@ -68,13 +63,31 @@ jobs:
           make -C external/gapbs -j2 bfs sssp converter
           test "$(git -C external/gapbs describe --tags --exact-match)" = "$GAPBS_TAG"
 
-      - name: Generate reduced contract graph
+      - name: Generate reduced non-canonical contract graph and provenance
         run: |
           mkdir -p artifacts/gap-contract
-          # This is deliberately NOT labelled canonical. It only tests the exact
-          # multiroot runner contract in hosted CI.
           external/gapbs/converter -g12 -k8 -e artifacts/gap-contract/kron.el
           external/gapbs/converter -g12 -k8 -e artifacts/gap-contract/kron.wel -w
+          python - <<'PY'
+          import hashlib, json
+          from pathlib import Path
+          d = Path('artifacts/gap-contract')
+          def sha(p): return hashlib.sha256(p.read_bytes()).hexdigest()
+          e, w = d/'kron.el', d/'kron.wel'
+          (d/'kron.metadata.json').write_text(json.dumps({
+              'schema_version': 2,
+              'dataset': 'kron',
+              'gap_revision': 'v1.5',
+              'recipe_source': 'CI contract only: GAP converter -g12 -k8; not canonical',
+              'canonical': False,
+              'directed': False,
+              'sssp_delta': 2,
+              'edge_list': 'kron.el',
+              'weighted_edge_list': 'kron.wel',
+              'checksums': {'edge_list_sha256': sha(e), 'weighted_edge_list_sha256': sha(w)},
+              'sizes_bytes': {'edge_list': e.stat().st_size, 'weighted_edge_list': w.stat().st_size},
+          }, indent=2, sort_keys=True) + '\n')
+          PY
 
       - name: Run multiroot correctness/timing contract
         run: |
@@ -83,31 +96,55 @@ jobs:
             --dataset-name kron \
             --edge-list artifacts/gap-contract/kron.el \
             --weighted-edge-list artifacts/gap-contract/kron.wel \
+            --dataset-metadata artifacts/gap-contract/kron.metadata.json \
             --velographx build/velographx_native_baseline_benchmark \
             --gap-bfs external/gapbs/bfs \
             --gap-sssp external/gapbs/sssp \
             --roots 0,1,7,31 \
             --threads 1,2 \
             --repeat 2 \
+            --sssp-delta 2 \
             --gap-revision "$GAPBS_TAG"
 
-      - name: Validate smoke is not canonical evidence
+      - name: Exercise fail-closed argument and semantics gates
+        run: |
+          set +e
+          python tools/run_gap_canonical_multiroot.py --output /tmp/x.json --dataset-name kron --edge-list artifacts/gap-contract/kron.el --weighted-edge-list artifacts/gap-contract/kron.wel --dataset-metadata artifacts/gap-contract/kron.metadata.json --velographx build/velographx_native_baseline_benchmark --gap-bfs external/gapbs/bfs --gap-sssp external/gapbs/sssp --roots 0,0 --threads 1 --repeat 1 --sssp-delta 2 --gap-revision v1.5 >/tmp/duplicate.log 2>&1
+          test $? -ne 0
+          python tools/run_gap_canonical_multiroot.py --output /tmp/y.json --dataset-name kron --edge-list artifacts/gap-contract/kron.el --weighted-edge-list artifacts/gap-contract/kron.wel --dataset-metadata artifacts/gap-contract/kron.metadata.json --velographx build/velographx_native_baseline_benchmark --gap-bfs external/gapbs/bfs --gap-sssp external/gapbs/sssp --roots 0,1 --threads 1 --repeat 1 --directed --sssp-delta 2 --gap-revision v1.5 >/tmp/directed.log 2>&1
+          test $? -ne 0
+          set -e
+          grep -q 'must not contain duplicates' /tmp/duplicate.log
+          grep -q 'directedness mismatch' /tmp/directed.log
+
+      - name: Validate smoke remains explicitly non-canonical
         run: |
           python - <<'PY'
           import json
           from pathlib import Path
           row = json.loads(Path('artifacts/gap-contract/result.json').read_text())
+          assert row['schema_version'] == 2
           assert row['campaign'] == 'gap-canonical-multiroot'
-          assert len(row['roots']) == 4
-          assert len(row['threads']) == 2
+          assert row['canonical_dataset_result'] is False
+          assert row['dataset_metadata']['provided'] is True
+          assert row['dataset_metadata']['canonical'] is False
+          assert row['directed'] is False and row['sssp_delta'] == 2
+          assert len(row['roots']) == 4 and len(set(row['roots'])) == 4
+          assert len(row['threads']) == 2 and all(x > 0 for x in row['threads'])
           assert len(row['rows']) == 8
+          assert row['correctness_gate']['passed'] is True
+          assert row['correctness_gate']['velographx_repeat_digest_stable'] is True
           assert all(x['bfs']['gap']['verification_passed'] for x in row['rows'])
           assert all(x['sssp']['gap']['verification_passed'] for x in row['rows'])
+          assert len(row['checksums']['edge_list_sha256']) == 64
+          assert len(row['checksums']['weighted_edge_list_sha256']) == 64
+          assert row['input_sizes_bytes']['edge_list'] > 0
+          assert row['input_sizes_bytes']['weighted_edge_list'] > 0
           Path('artifacts/gap-contract/metadata.json').write_text(json.dumps({
-              'schema_version': 1,
+              'schema_version': 2,
               'artifact_type': 'gap-multiroot-contract-smoke',
               'canonical_dataset_result': False,
-              'purpose': 'CI validation of the runner only; generated with -g12 -k8, not GAP canonical -g27 -k16',
+              'purpose': 'CI validation of provenance, semantics, correctness and failure gates only; -g12 -k8 is not GAP canonical -g27 -k16',
           }, indent=2, sort_keys=True) + '\n')
           PY
 
@@ -140,11 +177,12 @@ jobs:
           make -C external/gapbs -j2 bfs sssp converter
           test "$(git -C external/gapbs describe --tags --exact-match)" = "$GAPBS_TAG"
 
-      - name: Materialise exact canonical dataset
+      - name: Materialise and verify exact canonical dataset
         run: |
           bash tools/materialize_gap_canonical.sh external/gapbs '${{ inputs.dataset }}' artifacts/gap-canonical
+          sha256sum -c "artifacts/gap-canonical/${{ inputs.dataset }}.sha256" --ignore-missing
 
-      - name: Resolve corpus semantics
+      - name: Resolve canonical corpus semantics
         id: semantics
         shell: bash
         run: |
@@ -164,6 +202,7 @@ jobs:
             --dataset-name '${{ inputs.dataset }}' \
             --edge-list 'artifacts/gap-canonical/${{ inputs.dataset }}.el' \
             --weighted-edge-list 'artifacts/gap-canonical/${{ inputs.dataset }}.wel' \
+            --dataset-metadata 'artifacts/gap-canonical/${{ inputs.dataset }}.metadata.json' \
             --velographx build/velographx_native_baseline_benchmark \
             --gap-bfs external/gapbs/bfs \
             --gap-sssp external/gapbs/sssp \
@@ -174,7 +213,7 @@ jobs:
             --gap-revision "$GAPBS_TAG" \
             ${{ steps.semantics.outputs.directed }}
 
-      - name: Mark exact canonical evidence
+      - name: Mark exact canonical evidence only after all gates pass
         run: |
           python - <<'PY'
           import json
@@ -182,17 +221,23 @@ jobs:
           dataset = '${{ inputs.dataset }}'
           result = json.loads(Path(f'artifacts/gap-canonical/{dataset}.result.json').read_text())
           source = json.loads(Path(f'artifacts/gap-canonical/{dataset}.metadata.json').read_text())
-          assert source['canonical'] is True
+          assert source['schema_version'] == 2 and source['canonical'] is True
           assert source['gap_revision'] == 'v1.5'
-          assert len(result['roots']) >= 2
+          assert result['schema_version'] == 2
+          assert result['canonical_dataset_result'] is True
+          assert result['correctness_gate']['passed'] is True
+          assert result['checksums'] == source['checksums']
+          assert len(result['roots']) >= 2 and len(set(result['roots'])) == len(result['roots'])
           Path(f'artifacts/gap-canonical/{dataset}.evidence.json').write_text(json.dumps({
-              'schema_version': 1,
+              'schema_version': 2,
               'artifact_type': 'gap-canonical-multiroot-evidence',
               'canonical_dataset_result': True,
               'dataset': dataset,
               'gap_revision': 'v1.5',
               'roots': result['roots'],
               'threads': result['threads'],
+              'repeat': result['repeat'],
+              'checksums': result['checksums'],
               'correctness_gate': result['correctness_gate'],
           }, indent=2, sort_keys=True) + '\n')
           PY

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -9,9 +9,11 @@
 #include <utility>
 #include <vector>
 
+#include "data-structure/EdgeDoesNotExistsPrecondition.h"
 #include "data-structure/TransactionManager.h"
 #include "data-structure/VersionedBlockedEdgeIterator.h"
 #include "data-structure/VersioningBlockedSkipListAdjacencyList.h"
+#include "data-structure/VertexExistsPrecondition.h"
 #include "velographx/csr_graph.hpp"
 #include "velographx/incremental/bfs.hpp"
 #include "velographx/storage/dynamic_graph.hpp"
@@ -29,12 +31,7 @@ class Graph {
     manager_.register_thread(0);
     registered_ = true;
     std::cerr << "[sortledton-adapter] load-vertices\n";
-    for (VertexId v = 0; v < vertices_; ++v) {
-      auto tx = manager_.getSnapshotTransaction(&storage_, true);
-      tx.insert_vertex(v);
-      if (!tx.execute()) throw std::runtime_error("Sortledton vertex insertion failed at vertex " + std::to_string(v));
-      manager_.transactionCompleted(tx);
-    }
+    for (VertexId v = 0; v < vertices_; ++v) insert_vertex(v);
     std::cerr << "[sortledton-adapter] load-edges count=" << edges.size() << "\n";
     for (const auto& [u, v] : edges) insert_edge(u, v);
     std::cerr << "[sortledton-adapter] ready\n";
@@ -61,9 +58,22 @@ class Graph {
   std::uint64_t version_{0};
   bool registered_{false};
 
+  void insert_vertex(VertexId v) {
+    auto tx = manager_.getSnapshotTransaction(&storage_, true);
+    tx.insert_vertex(v);
+    if (!tx.execute()) throw std::runtime_error("Sortledton vertex insertion failed at vertex " + std::to_string(v));
+    manager_.transactionCompleted(tx);
+  }
+
   void insert_edge(VertexId u, VertexId v) {
     auto tx = manager_.getSnapshotTransaction(&storage_, true);
     const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
+    VertexExistsPrecondition source_exists(edge.src);
+    VertexExistsPrecondition destination_exists(edge.dst);
+    EdgeDoesNotExistsPrecondition edge_absent(edge);
+    tx.register_precondition(&source_exists);
+    tx.register_precondition(&destination_exists);
+    tx.register_precondition(&edge_absent);
     double weight = 1.0;
     tx.insert_edge(edge, reinterpret_cast<char*>(&weight), sizeof(weight));
     tx.insert_edge({edge.dst, edge.src}, reinterpret_cast<char*>(&weight), sizeof(weight));
@@ -97,14 +107,9 @@ void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
   while (iter.has_next_block()) {
     auto [versioned, begin, end] = iter.next_block();
     if (versioned) {
-      while (iter.has_next_edge()) {
-        const auto dst = iter.next();
-        fn(static_cast<VertexId>(tx.logical_id(dst)));
-      }
+      while (iter.has_next_edge()) fn(static_cast<VertexId>(tx.logical_id(iter.next())));
     } else {
-      for (auto it = begin; it < end; ++it) {
-        fn(static_cast<VertexId>(tx.logical_id(*it)));
-      }
+      for (auto it = begin; it < end; ++it) fn(static_cast<VertexId>(tx.logical_id(*it)));
     }
   }
   graph.manager_.transactionCompleted(tx);
@@ -124,8 +129,8 @@ void vx_apply_updates(Graph& graph, const UpdateBatch& batch) {
     const bool exists = vx_has_edge(graph, op.src, op.dst);
     if (op.add) {
       if (!exists) graph.insert_edge(op.src, op.dst);
-    } else {
-      if (exists) graph.delete_edge(op.src, op.dst);
+    } else if (exists) {
+      graph.delete_edge(op.src, op.dst);
     }
   }
   ++graph.version_;
@@ -198,21 +203,28 @@ std::uint64_t digest(const std::vector<std::uint32_t>& distances) {
 int run_campaign(std::size_t vertices) {
   const VertexId source = 0;
   const auto edges = make_graph(vertices);
+
+  // Establish the native oracle before constructing the external backend. This
+  // prevents an external-storage fault from being misattributed to CSR and also
+  // gives us immutable reference vectors for the exactness gate.
   std::cerr << "[sortledton-adapter] construct-native\n";
   DynamicGraph dynamic(vertices, false);
   dynamic.bulk_load_edges(edges);
   CsrGraph csr(edges, false);
-  std::cerr << "[sortledton-adapter] construct-sortledton\n";
-  sortledton_adapter::Graph sortledton_graph(vertices, edges);
-
-  std::vector<std::uint32_t> dynamic_dist, csr_dist, sortledton_dist;
+  std::vector<std::uint32_t> dynamic_dist, csr_dist;
   std::cerr << "[sortledton-adapter] recompute-dynamic\n";
   const auto dynamic_us = median_recompute_us(dynamic, source, dynamic_dist);
   std::cerr << "[sortledton-adapter] recompute-csr\n";
   const auto csr_us = median_recompute_us(csr, source, csr_dist);
+  if (dynamic_dist != csr_dist) throw std::runtime_error("native DynamicGraph/CSR oracle mismatch");
+  std::cerr << "[sortledton-adapter] native-oracle-ready\n";
+
+  std::cerr << "[sortledton-adapter] construct-sortledton\n";
+  sortledton_adapter::Graph sortledton_graph(vertices, edges);
+  std::vector<std::uint32_t> sortledton_dist;
   std::cerr << "[sortledton-adapter] recompute-sortledton\n";
   const auto sortledton_us = median_recompute_us(sortledton_graph, source, sortledton_dist);
-  const bool recompute_exact = dynamic_dist == csr_dist && dynamic_dist == sortledton_dist;
+  const bool recompute_exact = dynamic_dist == sortledton_dist;
 
   std::cerr << "[sortledton-adapter] incremental-construct\n";
   BasicIncrementalBFS<DynamicGraph> dynamic_incremental(dynamic, source);

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -4,6 +4,7 @@
 #include <iomanip>
 #include <iostream>
 #include <set>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -43,9 +44,9 @@ class Graph {
   void insert_edge(VertexId u, VertexId v) {
     auto tx = manager_.getSnapshotTransaction(&storage_, true);
     const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
-    const double weight = 1.0;
-    tx.insert_edge(edge, reinterpret_cast<const char*>(&weight), sizeof(weight));
-    tx.insert_edge({edge.dst, edge.src}, reinterpret_cast<const char*>(&weight), sizeof(weight));
+    double weight = 1.0;
+    tx.insert_edge(edge, reinterpret_cast<char*>(&weight), sizeof(weight));
+    tx.insert_edge({edge.dst, edge.src}, reinterpret_cast<char*>(&weight), sizeof(weight));
     if (!tx.execute()) throw std::runtime_error("Sortledton edge insertion failed");
     manager_.transactionCompleted(tx);
   }

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -27,7 +27,7 @@ using velographx::VertexId;
 class Graph {
  public:
   Graph(std::size_t vertices, const std::vector<std::pair<VertexId, VertexId>>& edges)
-      : vertices_(vertices), manager_(1), storage_(512, sizeof(double), manager_) {
+      : vertices_(vertices), manager_(1), storage_(1024, sizeof(double), manager_) {
     try { manager_.register_thread(0); } catch (...) { throw_stage("register_thread(0)"); }
     registered_ = true;
     for (VertexId v = 0; v < vertices_; ++v) insert_vertex(v);

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -153,15 +153,9 @@ void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
     try { physical = tx.physical_id(u); }
     catch (...) { throw_stage("neighbors physical_id u=" + std::to_string(u)); }
     try {
-      auto iter = tx.neighbourhood_blocked_p(physical);
-      while (iter.has_next_block()) {
-        auto [versioned, begin, end] = iter.next_block();
-        if (versioned) {
-          while (iter.has_next_edge()) fn(static_cast<VertexId>(tx.logical_id(iter.next())));
-        } else {
-          for (auto it = begin; it < end; ++it) fn(static_cast<VertexId>(tx.logical_id(*it)));
-        }
-      }
+      SORTLEDTON_ITERATE(tx, physical, {
+        fn(static_cast<VertexId>(tx.logical_id(e)));
+      });
     } catch (...) { throw_stage("neighbors iterate u=" + std::to_string(u)); }
     try { graph.manager_.transactionCompleted(tx); completed = true; }
     catch (...) { throw_stage("neighbors transactionCompleted u=" + std::to_string(u)); }

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -9,11 +9,9 @@
 #include <utility>
 #include <vector>
 
-#include "data-structure/EdgeDoesNotExistsPrecondition.h"
 #include "data-structure/TransactionManager.h"
 #include "data-structure/VersionedBlockedEdgeIterator.h"
 #include "data-structure/VersioningBlockedSkipListAdjacencyList.h"
-#include "data-structure/VertexExistsPrecondition.h"
 #include "velographx/csr_graph.hpp"
 #include "velographx/incremental/bfs.hpp"
 #include "velographx/storage/dynamic_graph.hpp"
@@ -75,12 +73,9 @@ class Graph {
     bool completed = false;
     try {
       const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
-      VertexExistsPrecondition source_exists(edge.src);
-      VertexExistsPrecondition destination_exists(edge.dst);
-      EdgeDoesNotExistsPrecondition edge_absent(edge);
-      tx.register_precondition(&source_exists);
-      tx.register_precondition(&destination_exists);
-      tx.register_precondition(&edge_absent);
+      tx.use_vertex_does_not_exists_semantics();
+      tx.insert_vertex(edge.src);
+      tx.insert_vertex(edge.dst);
       double weight = 1.0;
       tx.insert_edge(edge, reinterpret_cast<char*>(&weight), sizeof(weight));
       tx.insert_edge({edge.dst, edge.src}, reinterpret_cast<char*>(&weight), sizeof(weight));

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -26,6 +26,16 @@ using velographx::VertexId;
   throw std::runtime_error("Sortledton stage failed: " + stage);
 }
 
+class PinnedReadTransaction : public SnapshotTransaction {
+ public:
+  using SnapshotTransaction::SnapshotTransaction;
+
+  void pin(version_t version) {
+    clear(false);
+    read_version = version;
+  }
+};
+
 class Graph {
  public:
   Graph(std::size_t vertices, const std::vector<std::pair<VertexId, VertexId>>& edges)
@@ -49,6 +59,7 @@ class Graph {
   mutable TransactionManager manager_;
   mutable VersioningBlockedSkipListAdjacencyList storage_;
   std::uint64_t version_{0};
+  version_t storage_read_version_{NO_TRANSACTION};
   bool registered_{false};
 
   void insert_vertex(VertexId v) {
@@ -63,6 +74,7 @@ class Graph {
       bool ok = false;
       try { ok = tx.execute(); }
       catch (...) { throw_stage("insert_vertex execute v=" + std::to_string(v)); }
+      storage_read_version_ = tx.get_commit_version();
       try { manager_.transactionCompleted(tx); completed = true; }
       catch (...) { throw_stage("insert_vertex transactionCompleted v=" + std::to_string(v)); }
       if (!ok) throw std::runtime_error("Sortledton vertex insertion returned false v=" + std::to_string(v));
@@ -93,6 +105,7 @@ class Graph {
       bool ok = false;
       try { ok = tx.execute(); }
       catch (...) { throw_stage("insert_edge execute " + std::to_string(u) + "->" + std::to_string(v)); }
+      storage_read_version_ = tx.get_commit_version();
       try { manager_.transactionCompleted(tx); completed = true; }
       catch (...) { throw_stage("insert_edge transactionCompleted " + std::to_string(u) + "->" + std::to_string(v)); }
       if (!ok) throw std::runtime_error("Sortledton edge insertion returned false " + std::to_string(u) + "->" + std::to_string(v));
@@ -119,6 +132,7 @@ class Graph {
       bool ok = false;
       try { ok = tx.execute(); }
       catch (...) { throw_stage("delete_edge execute " + std::to_string(u) + "->" + std::to_string(v)); }
+      storage_read_version_ = tx.get_commit_version();
       try { manager_.transactionCompleted(tx); completed = true; }
       catch (...) { throw_stage("delete_edge transactionCompleted " + std::to_string(u) + "->" + std::to_string(v)); }
       if (!ok) throw std::runtime_error("Sortledton edge deletion returned false " + std::to_string(u) + "->" + std::to_string(v));
@@ -135,9 +149,11 @@ std::uint64_t vx_version(const Graph& graph) { return graph.version_; }
 
 template <class Fn>
 void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
-  SnapshotTransaction tx(&graph.manager_, true, &graph.storage_);
-  tx.clear(false);
-  tx.read_version = graph.manager_.get_epoch();
+  if (graph.storage_read_version_ == NO_TRANSACTION) {
+    throw_stage("neighbors missing committed read version");
+  }
+  PinnedReadTransaction tx(&graph.manager_, true, &graph.storage_);
+  tx.pin(graph.storage_read_version_);
 
   bool present = false;
   try { present = tx.has_vertex(u); }
@@ -207,16 +223,18 @@ void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
 }
 
 bool vx_has_edge(const Graph& graph, VertexId u, VertexId v) {
-  SnapshotTransaction tx(&graph.manager_, true, &graph.storage_);
-  tx.clear(false);
-  tx.read_version = graph.manager_.get_epoch();
+  if (graph.storage_read_version_ == NO_TRANSACTION) {
+    throw_stage("has_edge missing committed read version");
+  }
+  PinnedReadTransaction tx(&graph.manager_, true, &graph.storage_);
+  tx.pin(graph.storage_read_version_);
   try {
     if (!tx.has_vertex(u) || !tx.has_vertex(v)) return false;
     const auto pu = tx.physical_id(u);
     const auto pv = tx.physical_id(v);
     return tx.has_edge_p(edge_t{static_cast<dst_t>(pu), static_cast<dst_t>(pv)});
   } catch (...) {
-    throw_stage("has_edge quiescent read " + std::to_string(u) + "->" + std::to_string(v));
+    throw_stage("has_edge committed-version read " + std::to_string(u) + "->" + std::to_string(v));
   }
 }
 

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -30,7 +30,8 @@ class Graph {
  public:
   Graph(std::size_t vertices, const std::vector<std::pair<VertexId, VertexId>>& edges)
       : vertices_(vertices), manager_(1), storage_(1024, sizeof(double), manager_) {
-    try { manager_.register_thread(0); } catch (...) { throw_stage("register_thread(0)"); }
+    try { manager_.register_thread(0); }
+    catch (...) { throw_stage("register_thread(0)"); }
     registered_ = true;
     for (VertexId v = 0; v < vertices_; ++v) insert_vertex(v);
     for (const auto& [u, v] : edges) insert_edge(u, v);
@@ -50,7 +51,6 @@ class Graph {
   std::uint64_t version_{0};
   bool registered_{false};
 
- public:
   void insert_vertex(VertexId v) {
     SnapshotTransaction tx = [&]() {
       try { return manager_.getSnapshotTransaction(&storage_, true); }
@@ -87,7 +87,9 @@ class Graph {
         double weight = 1.0;
         tx.insert_edge(edge, reinterpret_cast<char*>(&weight), sizeof(weight));
         tx.insert_edge({edge.dst, edge.src}, reinterpret_cast<char*>(&weight), sizeof(weight));
-      } catch (...) { throw_stage("insert_edge enqueue " + std::to_string(u) + "->" + std::to_string(v)); }
+      } catch (...) {
+        throw_stage("insert_edge enqueue " + std::to_string(u) + "->" + std::to_string(v));
+      }
       bool ok = false;
       try { ok = tx.execute(); }
       catch (...) { throw_stage("insert_edge execute " + std::to_string(u) + "->" + std::to_string(v)); }
@@ -111,7 +113,9 @@ class Graph {
       try {
         tx.delete_edge(edge);
         tx.delete_edge({edge.dst, edge.src});
-      } catch (...) { throw_stage("delete_edge enqueue " + std::to_string(u) + "->" + std::to_string(v)); }
+      } catch (...) {
+        throw_stage("delete_edge enqueue " + std::to_string(u) + "->" + std::to_string(v));
+      }
       bool ok = false;
       try { ok = tx.execute(); }
       catch (...) { throw_stage("delete_edge execute " + std::to_string(u) + "->" + std::to_string(v)); }
@@ -131,25 +135,36 @@ std::uint64_t vx_version(const Graph& graph) { return graph.version_; }
 
 template <class Fn>
 void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
-  auto tx = graph.manager_.getSnapshotTransaction(&graph.storage_, false);
+  SnapshotTransaction tx = [&]() {
+    try { return graph.manager_.getSnapshotTransaction(&graph.storage_, false); }
+    catch (...) { throw_stage("neighbors getSnapshotTransaction u=" + std::to_string(u)); }
+  }();
   bool completed = false;
   try {
-    if (!tx.has_vertex(u)) {
-      graph.manager_.transactionCompleted(tx);
+    bool present = false;
+    try { present = tx.has_vertex(u); }
+    catch (...) { throw_stage("neighbors has_vertex u=" + std::to_string(u)); }
+    if (!present) {
+      try { graph.manager_.transactionCompleted(tx); completed = true; }
+      catch (...) { throw_stage("neighbors transactionCompleted absent u=" + std::to_string(u)); }
       return;
     }
-    const auto physical = tx.physical_id(u);
-    auto iter = tx.neighbourhood_blocked_p(physical);
-    while (iter.has_next_block()) {
-      auto [versioned, begin, end] = iter.next_block();
-      if (versioned) {
-        while (iter.has_next_edge()) fn(static_cast<VertexId>(tx.logical_id(iter.next())));
-      } else {
-        for (auto it = begin; it < end; ++it) fn(static_cast<VertexId>(tx.logical_id(*it)));
+    vertex_id_t physical = 0;
+    try { physical = tx.physical_id(u); }
+    catch (...) { throw_stage("neighbors physical_id u=" + std::to_string(u)); }
+    try {
+      auto iter = tx.neighbourhood_blocked_p(physical);
+      while (iter.has_next_block()) {
+        auto [versioned, begin, end] = iter.next_block();
+        if (versioned) {
+          while (iter.has_next_edge()) fn(static_cast<VertexId>(tx.logical_id(iter.next())));
+        } else {
+          for (auto it = begin; it < end; ++it) fn(static_cast<VertexId>(tx.logical_id(*it)));
+        }
       }
-    }
-    graph.manager_.transactionCompleted(tx);
-    completed = true;
+    } catch (...) { throw_stage("neighbors iterate u=" + std::to_string(u)); }
+    try { graph.manager_.transactionCompleted(tx); completed = true; }
+    catch (...) { throw_stage("neighbors transactionCompleted u=" + std::to_string(u)); }
   } catch (...) {
     if (!completed) { try { graph.manager_.transactionCompleted(tx); } catch (...) {} }
     throw;
@@ -157,17 +172,22 @@ void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
 }
 
 bool vx_has_edge(const Graph& graph, VertexId u, VertexId v) {
-  auto tx = graph.manager_.getSnapshotTransaction(&graph.storage_, false);
+  SnapshotTransaction tx = [&]() {
+    try { return graph.manager_.getSnapshotTransaction(&graph.storage_, false); }
+    catch (...) { throw_stage("has_edge getSnapshotTransaction " + std::to_string(u) + "->" + std::to_string(v)); }
+  }();
   bool completed = false;
   try {
     bool result = false;
-    if (tx.has_vertex(u) && tx.has_vertex(v)) {
-      const auto pu = tx.physical_id(u);
-      const auto pv = tx.physical_id(v);
-      result = tx.has_edge_p(edge_t{static_cast<dst_t>(pu), static_cast<dst_t>(pv)});
-    }
-    graph.manager_.transactionCompleted(tx);
-    completed = true;
+    try {
+      if (tx.has_vertex(u) && tx.has_vertex(v)) {
+        const auto pu = tx.physical_id(u);
+        const auto pv = tx.physical_id(v);
+        result = tx.has_edge_p(edge_t{static_cast<dst_t>(pu), static_cast<dst_t>(pv)});
+      }
+    } catch (...) { throw_stage("has_edge read " + std::to_string(u) + "->" + std::to_string(v)); }
+    try { graph.manager_.transactionCompleted(tx); completed = true; }
+    catch (...) { throw_stage("has_edge transactionCompleted " + std::to_string(u) + "->" + std::to_string(v)); }
     return result;
   } catch (...) {
     if (!completed) { try { graph.manager_.transactionCompleted(tx); } catch (...) {} }
@@ -257,6 +277,7 @@ int run(std::size_t vertices) {
   }
   const VertexId source = 0;
   const auto edges = make_graph(vertices);
+
   DynamicGraph dynamic(vertices, false);
   dynamic.bulk_load_edges(edges);
   CsrGraph csr(edges, false);
@@ -275,22 +296,31 @@ int run(std::size_t vertices) {
   std::vector<double> dynamic_samples, sortledton_samples;
   bool incremental_exact = true;
   for (const auto& batch : make_batches(vertices)) {
-    auto begin = std::chrono::steady_clock::now(); dynamic_inc.apply(batch); auto end = std::chrono::steady_clock::now();
+    auto begin = std::chrono::steady_clock::now();
+    dynamic_inc.apply(batch);
+    auto end = std::chrono::steady_clock::now();
     dynamic_samples.push_back(std::chrono::duration<double, std::micro>(end - begin).count());
-    begin = std::chrono::steady_clock::now(); sortledton_inc.apply(batch); end = std::chrono::steady_clock::now();
+
+    begin = std::chrono::steady_clock::now();
+    sortledton_inc.apply(batch);
+    end = std::chrono::steady_clock::now();
     sortledton_samples.push_back(std::chrono::duration<double, std::micro>(end - begin).count());
     incremental_exact = incremental_exact && dynamic_inc.distances() == sortledton_inc.distances();
   }
   std::sort(dynamic_samples.begin(), dynamic_samples.end());
   std::sort(sortledton_samples.begin(), sortledton_samples.end());
   const bool exact = recompute_exact && incremental_exact;
+
   std::cout << std::fixed << std::setprecision(3)
             << "{\"schema_version\":1,\"benchmark\":\"same-algorithm-storage-bfs\",\"backend\":\"sortledton\",\"algorithm\":\"BasicIncrementalBFS\",\"claim_scope\":\"correctness-and-storage-portability-only\",\"publication_grade\":false,"
             << "\"vertices\":" << vertices << ",\"edges\":" << edges.size() << ",\"source\":" << source
             << ",\"repetitions\":5,\"incremental_batches\":5,\"exact\":" << (exact ? "true" : "false")
-            << ",\"recompute_exact\":" << (recompute_exact ? "true" : "false") << ",\"incremental_exact\":" << (incremental_exact ? "true" : "false")
-            << ",\"digest\":" << digest(dynamic_inc.distances()) << ",\"dynamic_graph_median_us\":" << dynamic_us
-            << ",\"csr_graph_median_us\":" << csr_us << ",\"sortledton_median_us\":" << sortledton_us
+            << ",\"recompute_exact\":" << (recompute_exact ? "true" : "false")
+            << ",\"incremental_exact\":" << (incremental_exact ? "true" : "false")
+            << ",\"digest\":" << digest(dynamic_inc.distances())
+            << ",\"dynamic_graph_median_us\":" << dynamic_us
+            << ",\"csr_graph_median_us\":" << csr_us
+            << ",\"sortledton_median_us\":" << sortledton_us
             << ",\"dynamic_incremental_median_us\":" << dynamic_samples[dynamic_samples.size()/2]
             << ",\"sortledton_incremental_median_us\":" << sortledton_samples[sortledton_samples.size()/2] << "}\n";
   return exact ? 0 : 2;

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -24,6 +24,7 @@ class Graph {
  public:
   Graph(std::size_t vertices, const std::vector<std::pair<VertexId, VertexId>>& edges)
       : vertices_(vertices), manager_(1), storage_(512, sizeof(double), manager_) {
+    manager_.register_thread(0);
     for (VertexId v = 0; v < vertices_; ++v) {
       auto tx = manager_.getSnapshotTransaction(&storage_, true);
       tx.insert_vertex(v);
@@ -32,6 +33,8 @@ class Graph {
     }
     for (const auto& [u, v] : edges) insert_edge(u, v);
   }
+
+  ~Graph() { manager_.deregister_thread(0); }
 
   Graph(const Graph&) = delete;
   Graph& operator=(const Graph&) = delete;

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -20,11 +20,15 @@ namespace sortledton_adapter {
 using velographx::UpdateBatch;
 using velographx::VertexId;
 
+[[noreturn]] void throw_stage(const std::string& stage) {
+  throw std::runtime_error("Sortledton stage failed: " + stage);
+}
+
 class Graph {
  public:
   Graph(std::size_t vertices, const std::vector<std::pair<VertexId, VertexId>>& edges)
       : vertices_(vertices), manager_(1), storage_(512, sizeof(double), manager_) {
-    manager_.register_thread(0);
+    try { manager_.register_thread(0); } catch (...) { throw_stage("register_thread(0)"); }
     registered_ = true;
     for (VertexId v = 0; v < vertices_; ++v) insert_vertex(v);
     for (const auto& [u, v] : edges) insert_edge(u, v);
@@ -44,59 +48,78 @@ class Graph {
   std::uint64_t version_{0};
   bool registered_{false};
 
- private:
-  template <class Fn>
-  void write_transaction(Fn&& fn, const char* failure) {
-    auto tx = manager_.getSnapshotTransaction(&storage_, true);
+ public:
+  void insert_vertex(VertexId v) {
+    SnapshotTransaction tx = [&]() {
+      try { return manager_.getSnapshotTransaction(&storage_, true); }
+      catch (...) { throw_stage("insert_vertex getSnapshotTransaction v=" + std::to_string(v)); }
+    }();
     bool completed = false;
     try {
-      fn(tx);
-      const bool ok = tx.execute();
-      manager_.transactionCompleted(tx);
-      completed = true;
-      if (!ok) throw std::runtime_error(failure);
+      try { tx.insert_vertex(v); }
+      catch (...) { throw_stage("insert_vertex enqueue v=" + std::to_string(v)); }
+      bool ok = false;
+      try { ok = tx.execute(); }
+      catch (...) { throw_stage("insert_vertex execute v=" + std::to_string(v)); }
+      try { manager_.transactionCompleted(tx); completed = true; }
+      catch (...) { throw_stage("insert_vertex transactionCompleted v=" + std::to_string(v)); }
+      if (!ok) throw std::runtime_error("Sortledton vertex insertion returned false v=" + std::to_string(v));
     } catch (...) {
-      if (!completed) {
-        try { manager_.transactionCompleted(tx); } catch (...) {}
-      }
+      if (!completed) { try { manager_.transactionCompleted(tx); } catch (...) {} }
       throw;
     }
   }
 
- public:
-  void insert_vertex(VertexId v) {
-    write_transaction([&](auto& tx) { tx.insert_vertex(v); }, "Sortledton vertex insertion failed");
-  }
-
   void insert_edge(VertexId u, VertexId v) {
-    auto tx = manager_.getSnapshotTransaction(&storage_, true);
+    SnapshotTransaction tx = [&]() {
+      try { return manager_.getSnapshotTransaction(&storage_, true); }
+      catch (...) { throw_stage("insert_edge getSnapshotTransaction " + std::to_string(u) + "->" + std::to_string(v)); }
+    }();
     bool completed = false;
     try {
       const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
-      tx.use_vertex_does_not_exists_semantics();
-      tx.insert_vertex(edge.src);
-      tx.insert_vertex(edge.dst);
-      double weight = 1.0;
-      tx.insert_edge(edge, reinterpret_cast<char*>(&weight), sizeof(weight));
-      tx.insert_edge({edge.dst, edge.src}, reinterpret_cast<char*>(&weight), sizeof(weight));
-      const bool ok = tx.execute();
-      manager_.transactionCompleted(tx);
-      completed = true;
-      if (!ok) throw std::runtime_error("Sortledton edge insertion failed");
+      try {
+        tx.use_vertex_does_not_exists_semantics();
+        tx.insert_vertex(edge.src);
+        tx.insert_vertex(edge.dst);
+        double weight = 1.0;
+        tx.insert_edge(edge, reinterpret_cast<char*>(&weight), sizeof(weight));
+        tx.insert_edge({edge.dst, edge.src}, reinterpret_cast<char*>(&weight), sizeof(weight));
+      } catch (...) { throw_stage("insert_edge enqueue " + std::to_string(u) + "->" + std::to_string(v)); }
+      bool ok = false;
+      try { ok = tx.execute(); }
+      catch (...) { throw_stage("insert_edge execute " + std::to_string(u) + "->" + std::to_string(v)); }
+      try { manager_.transactionCompleted(tx); completed = true; }
+      catch (...) { throw_stage("insert_edge transactionCompleted " + std::to_string(u) + "->" + std::to_string(v)); }
+      if (!ok) throw std::runtime_error("Sortledton edge insertion returned false " + std::to_string(u) + "->" + std::to_string(v));
     } catch (...) {
-      if (!completed) {
-        try { manager_.transactionCompleted(tx); } catch (...) {}
-      }
+      if (!completed) { try { manager_.transactionCompleted(tx); } catch (...) {} }
       throw;
     }
   }
 
   void delete_edge(VertexId u, VertexId v) {
-    write_transaction([&](auto& tx) {
+    SnapshotTransaction tx = [&]() {
+      try { return manager_.getSnapshotTransaction(&storage_, true); }
+      catch (...) { throw_stage("delete_edge getSnapshotTransaction " + std::to_string(u) + "->" + std::to_string(v)); }
+    }();
+    bool completed = false;
+    try {
       const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
-      tx.delete_edge(edge);
-      tx.delete_edge({edge.dst, edge.src});
-    }, "Sortledton edge deletion failed");
+      try {
+        tx.delete_edge(edge);
+        tx.delete_edge({edge.dst, edge.src});
+      } catch (...) { throw_stage("delete_edge enqueue " + std::to_string(u) + "->" + std::to_string(v)); }
+      bool ok = false;
+      try { ok = tx.execute(); }
+      catch (...) { throw_stage("delete_edge execute " + std::to_string(u) + "->" + std::to_string(v)); }
+      try { manager_.transactionCompleted(tx); completed = true; }
+      catch (...) { throw_stage("delete_edge transactionCompleted " + std::to_string(u) + "->" + std::to_string(v)); }
+      if (!ok) throw std::runtime_error("Sortledton edge deletion returned false " + std::to_string(u) + "->" + std::to_string(v));
+    } catch (...) {
+      if (!completed) { try { manager_.transactionCompleted(tx); } catch (...) {} }
+      throw;
+    }
   }
 };
 
@@ -126,9 +149,7 @@ void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
     graph.manager_.transactionCompleted(tx);
     completed = true;
   } catch (...) {
-    if (!completed) {
-      try { graph.manager_.transactionCompleted(tx); } catch (...) {}
-    }
+    if (!completed) { try { graph.manager_.transactionCompleted(tx); } catch (...) {} }
     throw;
   }
 }
@@ -147,9 +168,7 @@ bool vx_has_edge(const Graph& graph, VertexId u, VertexId v) {
     completed = true;
     return result;
   } catch (...) {
-    if (!completed) {
-      try { graph.manager_.transactionCompleted(tx); } catch (...) {}
-    }
+    if (!completed) { try { graph.manager_.transactionCompleted(tx); } catch (...) {} }
     throw;
   }
 }
@@ -231,7 +250,6 @@ std::uint64_t digest(const std::vector<std::uint32_t>& distances) {
 int run(std::size_t vertices) {
   const VertexId source = 0;
   const auto edges = make_graph(vertices);
-
   DynamicGraph dynamic(vertices, false);
   dynamic.bulk_load_edges(edges);
   CsrGraph csr(edges, false);
@@ -250,43 +268,24 @@ int run(std::size_t vertices) {
   std::vector<double> dynamic_samples, sortledton_samples;
   bool incremental_exact = true;
   for (const auto& batch : make_batches(vertices)) {
-    auto begin = std::chrono::steady_clock::now();
-    dynamic_inc.apply(batch);
-    auto end = std::chrono::steady_clock::now();
+    auto begin = std::chrono::steady_clock::now(); dynamic_inc.apply(batch); auto end = std::chrono::steady_clock::now();
     dynamic_samples.push_back(std::chrono::duration<double, std::micro>(end - begin).count());
-
-    begin = std::chrono::steady_clock::now();
-    sortledton_inc.apply(batch);
-    end = std::chrono::steady_clock::now();
+    begin = std::chrono::steady_clock::now(); sortledton_inc.apply(batch); end = std::chrono::steady_clock::now();
     sortledton_samples.push_back(std::chrono::duration<double, std::micro>(end - begin).count());
     incremental_exact = incremental_exact && dynamic_inc.distances() == sortledton_inc.distances();
   }
   std::sort(dynamic_samples.begin(), dynamic_samples.end());
   std::sort(sortledton_samples.begin(), sortledton_samples.end());
   const bool exact = recompute_exact && incremental_exact;
-
   std::cout << std::fixed << std::setprecision(3)
-            << "{\"schema_version\":1,"
-            << "\"benchmark\":\"same-algorithm-storage-bfs\","
-            << "\"backend\":\"sortledton\","
-            << "\"algorithm\":\"BasicIncrementalBFS\","
-            << "\"claim_scope\":\"correctness-and-storage-portability-only\","
-            << "\"publication_grade\":false,"
-            << "\"vertices\":" << vertices << ','
-            << "\"edges\":" << edges.size() << ','
-            << "\"source\":" << source << ','
-            << "\"repetitions\":5,"
-            << "\"incremental_batches\":5,"
-            << "\"exact\":" << (exact ? "true" : "false") << ','
-            << "\"recompute_exact\":" << (recompute_exact ? "true" : "false") << ','
-            << "\"incremental_exact\":" << (incremental_exact ? "true" : "false") << ','
-            << "\"digest\":" << digest(dynamic_inc.distances()) << ','
-            << "\"dynamic_graph_median_us\":" << dynamic_us << ','
-            << "\"csr_graph_median_us\":" << csr_us << ','
-            << "\"sortledton_median_us\":" << sortledton_us << ','
-            << "\"dynamic_incremental_median_us\":" << dynamic_samples[dynamic_samples.size()/2] << ','
-            << "\"sortledton_incremental_median_us\":" << sortledton_samples[sortledton_samples.size()/2]
-            << "}\n";
+            << "{\"schema_version\":1,\"benchmark\":\"same-algorithm-storage-bfs\",\"backend\":\"sortledton\",\"algorithm\":\"BasicIncrementalBFS\",\"claim_scope\":\"correctness-and-storage-portability-only\",\"publication_grade\":false,"
+            << "\"vertices\":" << vertices << ",\"edges\":" << edges.size() << ",\"source\":" << source
+            << ",\"repetitions\":5,\"incremental_batches\":5,\"exact\":" << (exact ? "true" : "false")
+            << ",\"recompute_exact\":" << (recompute_exact ? "true" : "false") << ",\"incremental_exact\":" << (incremental_exact ? "true" : "false")
+            << ",\"digest\":" << digest(dynamic_inc.distances()) << ",\"dynamic_graph_median_us\":" << dynamic_us
+            << ",\"csr_graph_median_us\":" << csr_us << ",\"sortledton_median_us\":" << sortledton_us
+            << ",\"dynamic_incremental_median_us\":" << dynamic_samples[dynamic_samples.size()/2]
+            << ",\"sortledton_incremental_median_us\":" << sortledton_samples[sortledton_samples.size()/2] << "}\n";
   return exact ? 0 : 2;
 }
 }  // namespace

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <set>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -24,17 +25,32 @@ class Graph {
  public:
   Graph(std::size_t vertices, const std::vector<std::pair<VertexId, VertexId>>& edges)
       : vertices_(vertices), manager_(1), storage_(512, sizeof(double), manager_) {
+    std::cerr << "[sortledton-adapter] register-thread\n";
     manager_.register_thread(0);
+    registered_ = true;
+    std::cerr << "[sortledton-adapter] load-vertices\n";
     for (VertexId v = 0; v < vertices_; ++v) {
       auto tx = manager_.getSnapshotTransaction(&storage_, true);
       tx.insert_vertex(v);
-      if (!tx.execute()) throw std::runtime_error("Sortledton vertex insertion failed");
+      if (!tx.execute()) throw std::runtime_error("Sortledton vertex insertion failed at vertex " + std::to_string(v));
       manager_.transactionCompleted(tx);
     }
+    std::cerr << "[sortledton-adapter] load-edges count=" << edges.size() << "\n";
     for (const auto& [u, v] : edges) insert_edge(u, v);
+    std::cerr << "[sortledton-adapter] ready\n";
   }
 
-  ~Graph() { manager_.deregister_thread(0); }
+  ~Graph() noexcept {
+    if (registered_) {
+      try {
+        manager_.deregister_thread(0);
+      } catch (const std::exception& e) {
+        std::cerr << "[sortledton-adapter] deregister failure: " << e.what() << '\n';
+      } catch (...) {
+        std::cerr << "[sortledton-adapter] deregister failure: unknown exception\n";
+      }
+    }
+  }
 
   Graph(const Graph&) = delete;
   Graph& operator=(const Graph&) = delete;
@@ -43,6 +59,7 @@ class Graph {
   mutable TransactionManager manager_;
   mutable VersioningBlockedSkipListAdjacencyList storage_;
   std::uint64_t version_{0};
+  bool registered_{false};
 
   void insert_edge(VertexId u, VertexId v) {
     auto tx = manager_.getSnapshotTransaction(&storage_, true);
@@ -178,29 +195,33 @@ std::uint64_t digest(const std::vector<std::uint32_t>& distances) {
   return h;
 }
 
-}  // namespace
-
-int main(int argc, char** argv) {
-  const std::size_t vertices = argc > 1 ? static_cast<std::size_t>(std::stoull(argv[1])) : 8192;
+int run_campaign(std::size_t vertices) {
   const VertexId source = 0;
   const auto edges = make_graph(vertices);
-
+  std::cerr << "[sortledton-adapter] construct-native\n";
   DynamicGraph dynamic(vertices, false);
   dynamic.bulk_load_edges(edges);
   CsrGraph csr(edges, false);
+  std::cerr << "[sortledton-adapter] construct-sortledton\n";
   sortledton_adapter::Graph sortledton_graph(vertices, edges);
 
   std::vector<std::uint32_t> dynamic_dist, csr_dist, sortledton_dist;
+  std::cerr << "[sortledton-adapter] recompute-dynamic\n";
   const auto dynamic_us = median_recompute_us(dynamic, source, dynamic_dist);
+  std::cerr << "[sortledton-adapter] recompute-csr\n";
   const auto csr_us = median_recompute_us(csr, source, csr_dist);
+  std::cerr << "[sortledton-adapter] recompute-sortledton\n";
   const auto sortledton_us = median_recompute_us(sortledton_graph, source, sortledton_dist);
   const bool recompute_exact = dynamic_dist == csr_dist && dynamic_dist == sortledton_dist;
 
+  std::cerr << "[sortledton-adapter] incremental-construct\n";
   BasicIncrementalBFS<DynamicGraph> dynamic_incremental(dynamic, source);
   BasicIncrementalBFS<sortledton_adapter::Graph> sortledton_incremental(sortledton_graph, source);
   std::vector<double> dynamic_apply_samples, sortledton_apply_samples;
   bool incremental_exact = true;
+  int batch_index = 0;
   for (const auto& batch : make_incremental_batches(vertices)) {
+    std::cerr << "[sortledton-adapter] batch=" << batch_index << "\n";
     auto begin = std::chrono::steady_clock::now();
     dynamic_incremental.apply(batch);
     auto end = std::chrono::steady_clock::now();
@@ -211,6 +232,7 @@ int main(int argc, char** argv) {
     end = std::chrono::steady_clock::now();
     sortledton_apply_samples.push_back(std::chrono::duration<double, std::micro>(end - begin).count());
     incremental_exact = incremental_exact && dynamic_incremental.distances() == sortledton_incremental.distances();
+    ++batch_index;
   }
   std::sort(dynamic_apply_samples.begin(), dynamic_apply_samples.end());
   std::sort(sortledton_apply_samples.begin(), sortledton_apply_samples.end());
@@ -239,6 +261,22 @@ int main(int argc, char** argv) {
             << "\"sortledton_median_us\":" << sortledton_us << ','
             << "\"dynamic_incremental_median_us\":" << dynamic_apply_us << ','
             << "\"sortledton_incremental_median_us\":" << sortledton_apply_us
-            << "}\n";
+            << "}\n" << std::flush;
+  std::cerr << "[sortledton-adapter] result-emitted exact=" << exact << "\n";
   return exact ? 0 : 2;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  try {
+    const std::size_t vertices = argc > 1 ? static_cast<std::size_t>(std::stoull(argv[1])) : 8192;
+    return run_campaign(vertices);
+  } catch (const std::exception& e) {
+    std::cerr << "[sortledton-adapter] fatal exception: " << e.what() << '\n';
+    return 70;
+  } catch (...) {
+    std::cerr << "[sortledton-adapter] fatal unknown exception\n";
+    return 71;
+  }
 }

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -71,7 +71,9 @@ class Graph {
   }
 
   void insert_edge(VertexId u, VertexId v) {
-    write_transaction([&](auto& tx) {
+    auto tx = manager_.getSnapshotTransaction(&storage_, true);
+    bool completed = false;
+    try {
       const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
       VertexExistsPrecondition source_exists(edge.src);
       VertexExistsPrecondition destination_exists(edge.dst);
@@ -82,7 +84,16 @@ class Graph {
       double weight = 1.0;
       tx.insert_edge(edge, reinterpret_cast<char*>(&weight), sizeof(weight));
       tx.insert_edge({edge.dst, edge.src}, reinterpret_cast<char*>(&weight), sizeof(weight));
-    }, "Sortledton edge insertion failed");
+      const bool ok = tx.execute();
+      manager_.transactionCompleted(tx);
+      completed = true;
+      if (!ok) throw std::runtime_error("Sortledton edge insertion failed");
+    } catch (...) {
+      if (!completed) {
+        try { manager_.transactionCompleted(tx); } catch (...) {}
+      }
+      throw;
+    }
   }
 
   void delete_edge(VertexId u, VertexId v) {

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -135,10 +135,9 @@ std::uint64_t vx_version(const Graph& graph) { return graph.version_; }
 
 template <class Fn>
 void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
-  SnapshotTransaction tx = [&]() {
-    try { return graph.manager_.getSnapshotTransaction(&graph.storage_, false); }
-    catch (...) { throw_stage("neighbors getSnapshotTransaction u=" + std::to_string(u)); }
-  }();
+  SnapshotTransaction tx(&graph.manager_, true, &graph.storage_);
+  try { graph.manager_.getSnapshotTransaction(&graph.storage_, false, tx); }
+  catch (...) { throw_stage("neighbors reusable getSnapshotTransaction u=" + std::to_string(u)); }
   bool completed = false;
   try {
     bool present = false;
@@ -220,10 +219,9 @@ void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
 }
 
 bool vx_has_edge(const Graph& graph, VertexId u, VertexId v) {
-  SnapshotTransaction tx = [&]() {
-    try { return graph.manager_.getSnapshotTransaction(&graph.storage_, false); }
-    catch (...) { throw_stage("has_edge getSnapshotTransaction " + std::to_string(u) + "->" + std::to_string(v)); }
-  }();
+  SnapshotTransaction tx(&graph.manager_, true, &graph.storage_);
+  try { graph.manager_.getSnapshotTransaction(&graph.storage_, false, tx); }
+  catch (...) { throw_stage("has_edge reusable getSnapshotTransaction " + std::to_string(u) + "->" + std::to_string(v)); }
   bool completed = false;
   try {
     bool result = false;

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -19,7 +19,6 @@
 #include "velographx/storage/dynamic_graph.hpp"
 
 namespace sortledton_adapter {
-
 using velographx::UpdateBatch;
 using velographx::VertexId;
 
@@ -27,26 +26,15 @@ class Graph {
  public:
   Graph(std::size_t vertices, const std::vector<std::pair<VertexId, VertexId>>& edges)
       : vertices_(vertices), manager_(1), storage_(512, sizeof(double), manager_) {
-    std::cerr << "[sortledton-adapter] register-thread\n";
     manager_.register_thread(0);
     registered_ = true;
-    std::cerr << "[sortledton-adapter] load-vertices\n";
     for (VertexId v = 0; v < vertices_; ++v) insert_vertex(v);
-    std::cerr << "[sortledton-adapter] load-edges count=" << edges.size() << "\n";
-    for (const auto& [u, v] : edges) insert_edge(u, v, false);
-    std::cerr << "[sortledton-adapter] ready\n";
+    for (const auto& [u, v] : edges) insert_edge(u, v);
   }
 
   ~Graph() noexcept {
-    if (registered_) {
-      try {
-        manager_.deregister_thread(0);
-      } catch (const std::exception& e) {
-        std::cerr << "[sortledton-adapter] deregister failure: " << e.what() << '\n';
-      } catch (...) {
-        std::cerr << "[sortledton-adapter] deregister failure: unknown exception\n";
-      }
-    }
+    if (!registered_) return;
+    try { manager_.deregister_thread(0); } catch (...) {}
   }
 
   Graph(const Graph&) = delete;
@@ -58,23 +46,32 @@ class Graph {
   std::uint64_t version_{0};
   bool registered_{false};
 
-  void insert_vertex(VertexId v) {
+ private:
+  template <class Fn>
+  void write_transaction(Fn&& fn, const char* failure) {
     auto tx = manager_.getSnapshotTransaction(&storage_, true);
+    bool completed = false;
     try {
-      tx.insert_vertex(v);
+      fn(tx);
       const bool ok = tx.execute();
       manager_.transactionCompleted(tx);
-      if (!ok) throw std::runtime_error("Sortledton vertex insertion failed at vertex " + std::to_string(v));
+      completed = true;
+      if (!ok) throw std::runtime_error(failure);
     } catch (...) {
-      try { manager_.transactionCompleted(tx); } catch (...) {}
+      if (!completed) {
+        try { manager_.transactionCompleted(tx); } catch (...) {}
+      }
       throw;
     }
   }
 
-  void insert_edge(VertexId u, VertexId v, bool trace = true) {
-    if (trace) std::cerr << "[sortledton-adapter] update-insert " << u << ' ' << v << "\n";
-    auto tx = manager_.getSnapshotTransaction(&storage_, true);
-    try {
+ public:
+  void insert_vertex(VertexId v) {
+    write_transaction([&](auto& tx) { tx.insert_vertex(v); }, "Sortledton vertex insertion failed");
+  }
+
+  void insert_edge(VertexId u, VertexId v) {
+    write_transaction([&](auto& tx) {
       const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
       VertexExistsPrecondition source_exists(edge.src);
       VertexExistsPrecondition destination_exists(edge.dst);
@@ -85,33 +82,15 @@ class Graph {
       double weight = 1.0;
       tx.insert_edge(edge, reinterpret_cast<char*>(&weight), sizeof(weight));
       tx.insert_edge({edge.dst, edge.src}, reinterpret_cast<char*>(&weight), sizeof(weight));
-      const bool ok = tx.execute();
-      manager_.transactionCompleted(tx);
-      if (!ok) throw std::runtime_error("Sortledton edge insertion returned false");
-      if (trace) std::cerr << "[sortledton-adapter] update-insert-complete\n";
-    } catch (...) {
-      std::cerr << "[sortledton-adapter] update-insert-exception " << u << ' ' << v << "\n";
-      try { manager_.transactionCompleted(tx); } catch (...) {}
-      throw;
-    }
+    }, "Sortledton edge insertion failed");
   }
 
   void delete_edge(VertexId u, VertexId v) {
-    std::cerr << "[sortledton-adapter] update-delete " << u << ' ' << v << "\n";
-    auto tx = manager_.getSnapshotTransaction(&storage_, true);
-    try {
+    write_transaction([&](auto& tx) {
       const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
       tx.delete_edge(edge);
       tx.delete_edge({edge.dst, edge.src});
-      const bool ok = tx.execute();
-      manager_.transactionCompleted(tx);
-      if (!ok) throw std::runtime_error("Sortledton edge deletion returned false");
-      std::cerr << "[sortledton-adapter] update-delete-complete\n";
-    } catch (...) {
-      std::cerr << "[sortledton-adapter] update-delete-exception " << u << ' ' << v << "\n";
-      try { manager_.transactionCompleted(tx); } catch (...) {}
-      throw;
-    }
+    }, "Sortledton edge deletion failed");
   }
 };
 
@@ -122,6 +101,7 @@ std::uint64_t vx_version(const Graph& graph) { return graph.version_; }
 template <class Fn>
 void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
   auto tx = graph.manager_.getSnapshotTransaction(&graph.storage_, false);
+  bool completed = false;
   try {
     if (!tx.has_vertex(u)) {
       graph.manager_.transactionCompleted(tx);
@@ -138,32 +118,41 @@ void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
       }
     }
     graph.manager_.transactionCompleted(tx);
+    completed = true;
   } catch (...) {
-    try { graph.manager_.transactionCompleted(tx); } catch (...) {}
+    if (!completed) {
+      try { graph.manager_.transactionCompleted(tx); } catch (...) {}
+    }
     throw;
   }
 }
 
 bool vx_has_edge(const Graph& graph, VertexId u, VertexId v) {
   auto tx = graph.manager_.getSnapshotTransaction(&graph.storage_, false);
+  bool completed = false;
   try {
-    const bool result = tx.has_edge(edge_t{static_cast<dst_t>(u), static_cast<dst_t>(v)});
+    bool result = false;
+    if (tx.has_vertex(u) && tx.has_vertex(v)) {
+      const auto pu = tx.physical_id(u);
+      const auto pv = tx.physical_id(v);
+      result = tx.has_edge_p(edge_t{static_cast<dst_t>(pu), static_cast<dst_t>(pv)});
+    }
     graph.manager_.transactionCompleted(tx);
+    completed = true;
     return result;
   } catch (...) {
-    try { graph.manager_.transactionCompleted(tx); } catch (...) {}
+    if (!completed) {
+      try { graph.manager_.transactionCompleted(tx); } catch (...) {}
+    }
     throw;
   }
 }
 
 void vx_apply_updates(Graph& graph, const UpdateBatch& batch) {
   if (batch.empty()) return;
-  std::cerr << "[sortledton-adapter] update-batch-start ops=" << batch.updates.size() << "\n";
   for (const auto& op : batch.updates) {
     if (op.src >= graph.vertices_ || op.dst >= graph.vertices_) continue;
-    std::cerr << "[sortledton-adapter] update-check " << (op.add ? "add " : "del ") << op.src << ' ' << op.dst << "\n";
     const bool exists = vx_has_edge(graph, op.src, op.dst);
-    std::cerr << "[sortledton-adapter] update-exists=" << exists << "\n";
     if (op.add) {
       if (!exists) graph.insert_edge(op.src, op.dst);
     } else if (exists) {
@@ -171,13 +160,10 @@ void vx_apply_updates(Graph& graph, const UpdateBatch& batch) {
     }
   }
   ++graph.version_;
-  std::cerr << "[sortledton-adapter] update-batch-complete version=" << graph.version_ << "\n";
 }
-
 }  // namespace sortledton_adapter
 
 namespace {
-
 using velographx::BasicIncrementalBFS;
 using velographx::CsrGraph;
 using velographx::DynamicGraph;
@@ -198,9 +184,8 @@ std::vector<std::pair<VertexId, VertexId>> make_graph(std::size_t vertices) {
   return {unique.begin(), unique.end()};
 }
 
-std::vector<UpdateBatch> make_incremental_batches(std::size_t vertices) {
+std::vector<UpdateBatch> make_batches(std::size_t vertices) {
   std::vector<UpdateBatch> batches;
-  batches.reserve(5);
   for (VertexId i = 0; i < 5; ++i) {
     UpdateBatch batch;
     const auto u = static_cast<VertexId>((i * 17) % vertices);
@@ -217,7 +202,6 @@ template <class Graph>
 double median_recompute_us(Graph& graph, VertexId source, std::vector<std::uint32_t>& distances) {
   BasicIncrementalBFS<Graph> bfs(graph, source);
   std::vector<double> samples;
-  samples.reserve(5);
   for (int rep = 0; rep < 5; ++rep) {
     const auto begin = std::chrono::steady_clock::now();
     bfs.recompute();
@@ -238,53 +222,41 @@ std::uint64_t digest(const std::vector<std::uint32_t>& distances) {
   return h;
 }
 
-int run_campaign(std::size_t vertices) {
+int run(std::size_t vertices) {
   const VertexId source = 0;
   const auto edges = make_graph(vertices);
 
-  std::cerr << "[sortledton-adapter] construct-native\n";
   DynamicGraph dynamic(vertices, false);
   dynamic.bulk_load_edges(edges);
   CsrGraph csr(edges, false);
   std::vector<std::uint32_t> dynamic_dist, csr_dist;
-  std::cerr << "[sortledton-adapter] recompute-dynamic\n";
   const auto dynamic_us = median_recompute_us(dynamic, source, dynamic_dist);
-  std::cerr << "[sortledton-adapter] recompute-csr\n";
   const auto csr_us = median_recompute_us(csr, source, csr_dist);
   if (dynamic_dist != csr_dist) throw std::runtime_error("native DynamicGraph/CSR oracle mismatch");
-  std::cerr << "[sortledton-adapter] native-oracle-ready\n";
 
-  std::cerr << "[sortledton-adapter] construct-sortledton\n";
-  sortledton_adapter::Graph sortledton_graph(vertices, edges);
+  sortledton_adapter::Graph sortledton(vertices, edges);
   std::vector<std::uint32_t> sortledton_dist;
-  std::cerr << "[sortledton-adapter] recompute-sortledton\n";
-  const auto sortledton_us = median_recompute_us(sortledton_graph, source, sortledton_dist);
+  const auto sortledton_us = median_recompute_us(sortledton, source, sortledton_dist);
   const bool recompute_exact = dynamic_dist == sortledton_dist;
 
-  std::cerr << "[sortledton-adapter] incremental-construct\n";
-  BasicIncrementalBFS<DynamicGraph> dynamic_incremental(dynamic, source);
-  BasicIncrementalBFS<sortledton_adapter::Graph> sortledton_incremental(sortledton_graph, source);
-  std::vector<double> dynamic_apply_samples, sortledton_apply_samples;
+  BasicIncrementalBFS<DynamicGraph> dynamic_inc(dynamic, source);
+  BasicIncrementalBFS<sortledton_adapter::Graph> sortledton_inc(sortledton, source);
+  std::vector<double> dynamic_samples, sortledton_samples;
   bool incremental_exact = true;
-  int batch_index = 0;
-  for (const auto& batch : make_incremental_batches(vertices)) {
-    std::cerr << "[sortledton-adapter] batch=" << batch_index << "\n";
+  for (const auto& batch : make_batches(vertices)) {
     auto begin = std::chrono::steady_clock::now();
-    dynamic_incremental.apply(batch);
+    dynamic_inc.apply(batch);
     auto end = std::chrono::steady_clock::now();
-    dynamic_apply_samples.push_back(std::chrono::duration<double, std::micro>(end - begin).count());
+    dynamic_samples.push_back(std::chrono::duration<double, std::micro>(end - begin).count());
 
     begin = std::chrono::steady_clock::now();
-    sortledton_incremental.apply(batch);
+    sortledton_inc.apply(batch);
     end = std::chrono::steady_clock::now();
-    sortledton_apply_samples.push_back(std::chrono::duration<double, std::micro>(end - begin).count());
-    incremental_exact = incremental_exact && dynamic_incremental.distances() == sortledton_incremental.distances();
-    ++batch_index;
+    sortledton_samples.push_back(std::chrono::duration<double, std::micro>(end - begin).count());
+    incremental_exact = incremental_exact && dynamic_inc.distances() == sortledton_inc.distances();
   }
-  std::sort(dynamic_apply_samples.begin(), dynamic_apply_samples.end());
-  std::sort(sortledton_apply_samples.begin(), sortledton_apply_samples.end());
-  const auto dynamic_apply_us = dynamic_apply_samples[dynamic_apply_samples.size() / 2];
-  const auto sortledton_apply_us = sortledton_apply_samples[sortledton_apply_samples.size() / 2];
+  std::sort(dynamic_samples.begin(), dynamic_samples.end());
+  std::sort(sortledton_samples.begin(), sortledton_samples.end());
   const bool exact = recompute_exact && incremental_exact;
 
   std::cout << std::fixed << std::setprecision(3)
@@ -302,28 +274,26 @@ int run_campaign(std::size_t vertices) {
             << "\"exact\":" << (exact ? "true" : "false") << ','
             << "\"recompute_exact\":" << (recompute_exact ? "true" : "false") << ','
             << "\"incremental_exact\":" << (incremental_exact ? "true" : "false") << ','
-            << "\"digest\":" << digest(dynamic_incremental.distances()) << ','
+            << "\"digest\":" << digest(dynamic_inc.distances()) << ','
             << "\"dynamic_graph_median_us\":" << dynamic_us << ','
             << "\"csr_graph_median_us\":" << csr_us << ','
             << "\"sortledton_median_us\":" << sortledton_us << ','
-            << "\"dynamic_incremental_median_us\":" << dynamic_apply_us << ','
-            << "\"sortledton_incremental_median_us\":" << sortledton_apply_us
-            << "}\n" << std::flush;
-  std::cerr << "[sortledton-adapter] result-emitted exact=" << exact << "\n";
+            << "\"dynamic_incremental_median_us\":" << dynamic_samples[dynamic_samples.size()/2] << ','
+            << "\"sortledton_incremental_median_us\":" << sortledton_samples[sortledton_samples.size()/2]
+            << "}\n";
   return exact ? 0 : 2;
 }
-
 }  // namespace
 
 int main(int argc, char** argv) {
   try {
     const std::size_t vertices = argc > 1 ? static_cast<std::size_t>(std::stoull(argv[1])) : 8192;
-    return run_campaign(vertices);
+    return run(vertices);
   } catch (const std::exception& e) {
-    std::cerr << "[sortledton-adapter] fatal exception: " << e.what() << '\n';
+    std::cerr << "Sortledton adapter error: " << e.what() << '\n';
     return 70;
   } catch (...) {
-    std::cerr << "[sortledton-adapter] fatal unknown exception\n";
+    std::cerr << "Sortledton adapter error: non-standard upstream exception\n";
     return 71;
   }
 }

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -33,7 +33,7 @@ class Graph {
     std::cerr << "[sortledton-adapter] load-vertices\n";
     for (VertexId v = 0; v < vertices_; ++v) insert_vertex(v);
     std::cerr << "[sortledton-adapter] load-edges count=" << edges.size() << "\n";
-    for (const auto& [u, v] : edges) insert_edge(u, v);
+    for (const auto& [u, v] : edges) insert_edge(u, v, false);
     std::cerr << "[sortledton-adapter] ready\n";
   }
 
@@ -60,34 +60,58 @@ class Graph {
 
   void insert_vertex(VertexId v) {
     auto tx = manager_.getSnapshotTransaction(&storage_, true);
-    tx.insert_vertex(v);
-    if (!tx.execute()) throw std::runtime_error("Sortledton vertex insertion failed at vertex " + std::to_string(v));
-    manager_.transactionCompleted(tx);
+    try {
+      tx.insert_vertex(v);
+      const bool ok = tx.execute();
+      manager_.transactionCompleted(tx);
+      if (!ok) throw std::runtime_error("Sortledton vertex insertion failed at vertex " + std::to_string(v));
+    } catch (...) {
+      try { manager_.transactionCompleted(tx); } catch (...) {}
+      throw;
+    }
   }
 
-  void insert_edge(VertexId u, VertexId v) {
+  void insert_edge(VertexId u, VertexId v, bool trace = true) {
+    if (trace) std::cerr << "[sortledton-adapter] update-insert " << u << ' ' << v << "\n";
     auto tx = manager_.getSnapshotTransaction(&storage_, true);
-    const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
-    VertexExistsPrecondition source_exists(edge.src);
-    VertexExistsPrecondition destination_exists(edge.dst);
-    EdgeDoesNotExistsPrecondition edge_absent(edge);
-    tx.register_precondition(&source_exists);
-    tx.register_precondition(&destination_exists);
-    tx.register_precondition(&edge_absent);
-    double weight = 1.0;
-    tx.insert_edge(edge, reinterpret_cast<char*>(&weight), sizeof(weight));
-    tx.insert_edge({edge.dst, edge.src}, reinterpret_cast<char*>(&weight), sizeof(weight));
-    if (!tx.execute()) throw std::runtime_error("Sortledton edge insertion failed");
-    manager_.transactionCompleted(tx);
+    try {
+      const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
+      VertexExistsPrecondition source_exists(edge.src);
+      VertexExistsPrecondition destination_exists(edge.dst);
+      EdgeDoesNotExistsPrecondition edge_absent(edge);
+      tx.register_precondition(&source_exists);
+      tx.register_precondition(&destination_exists);
+      tx.register_precondition(&edge_absent);
+      double weight = 1.0;
+      tx.insert_edge(edge, reinterpret_cast<char*>(&weight), sizeof(weight));
+      tx.insert_edge({edge.dst, edge.src}, reinterpret_cast<char*>(&weight), sizeof(weight));
+      const bool ok = tx.execute();
+      manager_.transactionCompleted(tx);
+      if (!ok) throw std::runtime_error("Sortledton edge insertion returned false");
+      if (trace) std::cerr << "[sortledton-adapter] update-insert-complete\n";
+    } catch (...) {
+      std::cerr << "[sortledton-adapter] update-insert-exception " << u << ' ' << v << "\n";
+      try { manager_.transactionCompleted(tx); } catch (...) {}
+      throw;
+    }
   }
 
   void delete_edge(VertexId u, VertexId v) {
+    std::cerr << "[sortledton-adapter] update-delete " << u << ' ' << v << "\n";
     auto tx = manager_.getSnapshotTransaction(&storage_, true);
-    const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
-    tx.delete_edge(edge);
-    tx.delete_edge({edge.dst, edge.src});
-    if (!tx.execute()) throw std::runtime_error("Sortledton edge deletion failed");
-    manager_.transactionCompleted(tx);
+    try {
+      const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
+      tx.delete_edge(edge);
+      tx.delete_edge({edge.dst, edge.src});
+      const bool ok = tx.execute();
+      manager_.transactionCompleted(tx);
+      if (!ok) throw std::runtime_error("Sortledton edge deletion returned false");
+      std::cerr << "[sortledton-adapter] update-delete-complete\n";
+    } catch (...) {
+      std::cerr << "[sortledton-adapter] update-delete-exception " << u << ' ' << v << "\n";
+      try { manager_.transactionCompleted(tx); } catch (...) {}
+      throw;
+    }
   }
 };
 
@@ -98,35 +122,48 @@ std::uint64_t vx_version(const Graph& graph) { return graph.version_; }
 template <class Fn>
 void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
   auto tx = graph.manager_.getSnapshotTransaction(&graph.storage_, false);
-  if (!tx.has_vertex(u)) {
-    graph.manager_.transactionCompleted(tx);
-    return;
-  }
-  const auto physical = tx.physical_id(u);
-  auto iter = tx.neighbourhood_blocked_p(physical);
-  while (iter.has_next_block()) {
-    auto [versioned, begin, end] = iter.next_block();
-    if (versioned) {
-      while (iter.has_next_edge()) fn(static_cast<VertexId>(tx.logical_id(iter.next())));
-    } else {
-      for (auto it = begin; it < end; ++it) fn(static_cast<VertexId>(tx.logical_id(*it)));
+  try {
+    if (!tx.has_vertex(u)) {
+      graph.manager_.transactionCompleted(tx);
+      return;
     }
+    const auto physical = tx.physical_id(u);
+    auto iter = tx.neighbourhood_blocked_p(physical);
+    while (iter.has_next_block()) {
+      auto [versioned, begin, end] = iter.next_block();
+      if (versioned) {
+        while (iter.has_next_edge()) fn(static_cast<VertexId>(tx.logical_id(iter.next())));
+      } else {
+        for (auto it = begin; it < end; ++it) fn(static_cast<VertexId>(tx.logical_id(*it)));
+      }
+    }
+    graph.manager_.transactionCompleted(tx);
+  } catch (...) {
+    try { graph.manager_.transactionCompleted(tx); } catch (...) {}
+    throw;
   }
-  graph.manager_.transactionCompleted(tx);
 }
 
 bool vx_has_edge(const Graph& graph, VertexId u, VertexId v) {
   auto tx = graph.manager_.getSnapshotTransaction(&graph.storage_, false);
-  const bool result = tx.has_edge(edge_t{static_cast<dst_t>(u), static_cast<dst_t>(v)});
-  graph.manager_.transactionCompleted(tx);
-  return result;
+  try {
+    const bool result = tx.has_edge(edge_t{static_cast<dst_t>(u), static_cast<dst_t>(v)});
+    graph.manager_.transactionCompleted(tx);
+    return result;
+  } catch (...) {
+    try { graph.manager_.transactionCompleted(tx); } catch (...) {}
+    throw;
+  }
 }
 
 void vx_apply_updates(Graph& graph, const UpdateBatch& batch) {
   if (batch.empty()) return;
+  std::cerr << "[sortledton-adapter] update-batch-start ops=" << batch.updates.size() << "\n";
   for (const auto& op : batch.updates) {
     if (op.src >= graph.vertices_ || op.dst >= graph.vertices_) continue;
+    std::cerr << "[sortledton-adapter] update-check " << (op.add ? "add " : "del ") << op.src << ' ' << op.dst << "\n";
     const bool exists = vx_has_edge(graph, op.src, op.dst);
+    std::cerr << "[sortledton-adapter] update-exists=" << exists << "\n";
     if (op.add) {
       if (!exists) graph.insert_edge(op.src, op.dst);
     } else if (exists) {
@@ -134,6 +171,7 @@ void vx_apply_updates(Graph& graph, const UpdateBatch& batch) {
     }
   }
   ++graph.version_;
+  std::cerr << "[sortledton-adapter] update-batch-complete version=" << graph.version_ << "\n";
 }
 
 }  // namespace sortledton_adapter
@@ -204,9 +242,6 @@ int run_campaign(std::size_t vertices) {
   const VertexId source = 0;
   const auto edges = make_graph(vertices);
 
-  // Establish the native oracle before constructing the external backend. This
-  // prevents an external-storage fault from being misattributed to CSR and also
-  // gives us immutable reference vectors for the exactness gate.
   std::cerr << "[sortledton-adapter] construct-native\n";
   DynamicGraph dynamic(vertices, false);
   dynamic.bulk_load_edges(edges);

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -177,18 +177,31 @@ void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
 
     try {
       while (iter.has_next_block()) {
-        auto [begin, end] = iter.next_block();
-        for (auto it = begin; it < end; ++it) {
-          if (isDeleted(*it)) continue;
-          const auto raw = *it;
-          const auto unversioned = make_unversioned(raw);
-          VertexId logical = 0;
-          try { logical = static_cast<VertexId>(tx.logical_id(unversioned)); }
-          catch (...) {
-            throw_stage("neighbors logical_id u=" + std::to_string(u) + " p=" + std::to_string(physical) +
-                        " raw=" + std::to_string(raw) + " unversioned=" + std::to_string(unversioned));
+        auto [versioned, begin, end] = iter.next_block();
+        if (versioned) {
+          while (iter.has_next_edge()) {
+            const auto raw = iter.next();
+            const auto unversioned = make_unversioned(raw);
+            VertexId logical = 0;
+            try { logical = static_cast<VertexId>(tx.logical_id(unversioned)); }
+            catch (...) {
+              throw_stage("neighbors logical_id versioned u=" + std::to_string(u) + " p=" + std::to_string(physical) +
+                          " raw=" + std::to_string(raw) + " unversioned=" + std::to_string(unversioned));
+            }
+            fn(logical);
           }
-          fn(logical);
+        } else {
+          for (auto it = begin; it < end; ++it) {
+            const auto raw = *it;
+            const auto unversioned = make_unversioned(raw);
+            VertexId logical = 0;
+            try { logical = static_cast<VertexId>(tx.logical_id(unversioned)); }
+            catch (...) {
+              throw_stage("neighbors logical_id plain u=" + std::to_string(u) + " p=" + std::to_string(physical) +
+                          " raw=" + std::to_string(raw) + " unversioned=" + std::to_string(unversioned));
+            }
+            fn(logical);
+          }
         }
       }
     } catch (const std::runtime_error&) {

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -154,7 +154,7 @@ void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
     catch (...) { throw_stage("neighbors physical_id u=" + std::to_string(u)); }
     try {
       SORTLEDTON_ITERATE(tx, physical, {
-        fn(static_cast<VertexId>(tx.logical_id(e)));
+        fn(static_cast<VertexId>(tx.logical_id(make_unversioned(e))));
       });
     } catch (...) { throw_stage("neighbors iterate u=" + std::to_string(u)); }
     try { graph.manager_.transactionCompleted(tx); completed = true; }

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -136,108 +136,87 @@ std::uint64_t vx_version(const Graph& graph) { return graph.version_; }
 template <class Fn>
 void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
   SnapshotTransaction tx(&graph.manager_, true, &graph.storage_);
-  try { graph.manager_.getSnapshotTransaction(&graph.storage_, false, tx); }
-  catch (...) { throw_stage("neighbors reusable getSnapshotTransaction u=" + std::to_string(u)); }
-  bool completed = false;
-  try {
-    bool present = false;
-    try { present = tx.has_vertex(u); }
-    catch (...) { throw_stage("neighbors has_vertex u=" + std::to_string(u)); }
-    if (!present) {
-      try { graph.manager_.transactionCompleted(tx); completed = true; }
-      catch (...) { throw_stage("neighbors transactionCompleted absent u=" + std::to_string(u)); }
-      return;
-    }
+  tx.clear(false);
+  tx.read_version = graph.manager_.get_epoch();
 
-    vertex_id_t physical = 0;
-    try { physical = tx.physical_id(u); }
-    catch (...) { throw_stage("neighbors physical_id u=" + std::to_string(u)); }
+  bool present = false;
+  try { present = tx.has_vertex(u); }
+  catch (...) { throw_stage("neighbors has_vertex u=" + std::to_string(u)); }
+  if (!present) return;
 
-    std::size_t degree = 0;
-    try { degree = tx.neighbourhood_size_p(physical); }
-    catch (...) { throw_stage("neighbors degree u=" + std::to_string(u) + " p=" + std::to_string(physical)); }
+  vertex_id_t physical = 0;
+  try { physical = tx.physical_id(u); }
+  catch (...) { throw_stage("neighbors physical_id u=" + std::to_string(u)); }
 
-    const auto read_version = tx.get_version();
-    int set_type = -1;
-    try { set_type = static_cast<int>(graph.storage_.get_set_type(physical, read_version)); }
+  std::size_t degree = 0;
+  try { degree = tx.neighbourhood_size_p(physical); }
+  catch (...) { throw_stage("neighbors degree u=" + std::to_string(u) + " p=" + std::to_string(physical)); }
+
+  const auto read_version = tx.get_version();
+  int set_type = -1;
+  try { set_type = static_cast<int>(graph.storage_.get_set_type(physical, read_version)); }
+  catch (...) {
+    throw_stage("neighbors set_type u=" + std::to_string(u) + " p=" + std::to_string(physical) +
+                " degree=" + std::to_string(degree) + " version=" + std::to_string(read_version));
+  }
+
+  auto iter = [&]() {
+    try { return tx.neighbourhood_blocked_p(physical); }
     catch (...) {
-      throw_stage("neighbors set_type u=" + std::to_string(u) + " p=" + std::to_string(physical) +
-                  " degree=" + std::to_string(degree) + " version=" + std::to_string(read_version));
+      throw_stage("neighbors iterator-create u=" + std::to_string(u) + " p=" + std::to_string(physical) +
+                  " degree=" + std::to_string(degree) + " type=" + std::to_string(set_type) +
+                  " version=" + std::to_string(read_version));
     }
+  }();
 
-    auto iter = [&]() {
-      try { return tx.neighbourhood_blocked_p(physical); }
-      catch (...) {
-        throw_stage("neighbors iterator-create u=" + std::to_string(u) + " p=" + std::to_string(physical) +
-                    " degree=" + std::to_string(degree) + " type=" + std::to_string(set_type) +
-                    " version=" + std::to_string(read_version));
-      }
-    }();
-
-    try {
-      while (iter.has_next_block()) {
-        auto [versioned, begin, end] = iter.next_block();
-        if (versioned) {
-          while (iter.has_next_edge()) {
-            const auto raw = iter.next();
-            const auto unversioned = make_unversioned(raw);
-            VertexId logical = 0;
-            try { logical = static_cast<VertexId>(tx.logical_id(unversioned)); }
-            catch (...) {
-              throw_stage("neighbors logical_id versioned u=" + std::to_string(u) + " p=" + std::to_string(physical) +
-                          " raw=" + std::to_string(raw) + " unversioned=" + std::to_string(unversioned));
-            }
-            fn(logical);
+  try {
+    while (iter.has_next_block()) {
+      auto [versioned, begin, end] = iter.next_block();
+      if (versioned) {
+        while (iter.has_next_edge()) {
+          const auto raw = iter.next();
+          const auto unversioned = make_unversioned(raw);
+          VertexId logical = 0;
+          try { logical = static_cast<VertexId>(tx.logical_id(unversioned)); }
+          catch (...) {
+            throw_stage("neighbors logical_id versioned u=" + std::to_string(u) + " p=" + std::to_string(physical) +
+                        " raw=" + std::to_string(raw) + " unversioned=" + std::to_string(unversioned));
           }
-        } else {
-          for (auto it = begin; it < end; ++it) {
-            const auto raw = *it;
-            const auto unversioned = make_unversioned(raw);
-            VertexId logical = 0;
-            try { logical = static_cast<VertexId>(tx.logical_id(unversioned)); }
-            catch (...) {
-              throw_stage("neighbors logical_id plain u=" + std::to_string(u) + " p=" + std::to_string(physical) +
-                          " raw=" + std::to_string(raw) + " unversioned=" + std::to_string(unversioned));
-            }
-            fn(logical);
+          fn(logical);
+        }
+      } else {
+        for (auto it = begin; it < end; ++it) {
+          const auto raw = *it;
+          const auto unversioned = make_unversioned(raw);
+          VertexId logical = 0;
+          try { logical = static_cast<VertexId>(tx.logical_id(unversioned)); }
+          catch (...) {
+            throw_stage("neighbors logical_id plain u=" + std::to_string(u) + " p=" + std::to_string(physical) +
+                        " raw=" + std::to_string(raw) + " unversioned=" + std::to_string(unversioned));
           }
+          fn(logical);
         }
       }
-    } catch (const std::runtime_error&) {
-      throw;
-    } catch (...) {
-      throw_stage("neighbors iterator-walk u=" + std::to_string(u) + " p=" + std::to_string(physical) +
-                  " degree=" + std::to_string(degree) + " type=" + std::to_string(set_type));
     }
-
-    try { graph.manager_.transactionCompleted(tx); completed = true; }
-    catch (...) { throw_stage("neighbors transactionCompleted u=" + std::to_string(u)); }
-  } catch (...) {
-    if (!completed) { try { graph.manager_.transactionCompleted(tx); } catch (...) {} }
+  } catch (const std::runtime_error&) {
     throw;
+  } catch (...) {
+    throw_stage("neighbors iterator-walk u=" + std::to_string(u) + " p=" + std::to_string(physical) +
+                " degree=" + std::to_string(degree) + " type=" + std::to_string(set_type));
   }
 }
 
 bool vx_has_edge(const Graph& graph, VertexId u, VertexId v) {
   SnapshotTransaction tx(&graph.manager_, true, &graph.storage_);
-  try { graph.manager_.getSnapshotTransaction(&graph.storage_, false, tx); }
-  catch (...) { throw_stage("has_edge reusable getSnapshotTransaction " + std::to_string(u) + "->" + std::to_string(v)); }
-  bool completed = false;
+  tx.clear(false);
+  tx.read_version = graph.manager_.get_epoch();
   try {
-    bool result = false;
-    try {
-      if (tx.has_vertex(u) && tx.has_vertex(v)) {
-        const auto pu = tx.physical_id(u);
-        const auto pv = tx.physical_id(v);
-        result = tx.has_edge_p(edge_t{static_cast<dst_t>(pu), static_cast<dst_t>(pv)});
-      }
-    } catch (...) { throw_stage("has_edge read " + std::to_string(u) + "->" + std::to_string(v)); }
-    try { graph.manager_.transactionCompleted(tx); completed = true; }
-    catch (...) { throw_stage("has_edge transactionCompleted " + std::to_string(u) + "->" + std::to_string(v)); }
-    return result;
+    if (!tx.has_vertex(u) || !tx.has_vertex(v)) return false;
+    const auto pu = tx.physical_id(u);
+    const auto pv = tx.physical_id(v);
+    return tx.has_edge_p(edge_t{static_cast<dst_t>(pu), static_cast<dst_t>(pv)});
   } catch (...) {
-    if (!completed) { try { graph.manager_.transactionCompleted(tx); } catch (...) {} }
-    throw;
+    throw_stage("has_edge quiescent read " + std::to_string(u) + "->" + std::to_string(v));
   }
 }
 

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 
+#include "internal-driver/Configuration.h"
+#include "utils/utils.h"
 #include "data-structure/TransactionManager.h"
 #include "data-structure/VersionedBlockedEdgeIterator.h"
 #include "data-structure/VersioningBlockedSkipListAdjacencyList.h"
@@ -248,6 +250,11 @@ std::uint64_t digest(const std::vector<std::uint32_t>& distances) {
 }
 
 int run(std::size_t vertices) {
+  constexpr unsigned kSortledtonBlockSize = 1024;
+  const auto rounded = round_up_power_of_two(kSortledtonBlockSize);
+  if (rounded != kSortledtonBlockSize) {
+    throw std::runtime_error("Sortledton round_up_power_of_two probe mismatch: " + std::to_string(rounded));
+  }
   const VertexId source = 0;
   const auto edges = make_graph(vertices);
   DynamicGraph dynamic(vertices, false);
@@ -294,6 +301,9 @@ int main(int argc, char** argv) {
   try {
     const std::size_t vertices = argc > 1 ? static_cast<std::size_t>(std::stoull(argv[1])) : 8192;
     return run(vertices);
+  } catch (const ConfigurationError& e) {
+    std::cerr << "Sortledton configuration error: " << e.what() << '\n';
+    return 72;
   } catch (const std::exception& e) {
     std::cerr << "Sortledton adapter error: " << e.what() << '\n';
     return 70;

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -149,14 +149,55 @@ void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
       catch (...) { throw_stage("neighbors transactionCompleted absent u=" + std::to_string(u)); }
       return;
     }
+
     vertex_id_t physical = 0;
     try { physical = tx.physical_id(u); }
     catch (...) { throw_stage("neighbors physical_id u=" + std::to_string(u)); }
+
+    std::size_t degree = 0;
+    try { degree = tx.neighbourhood_size_p(physical); }
+    catch (...) { throw_stage("neighbors degree u=" + std::to_string(u) + " p=" + std::to_string(physical)); }
+
+    const auto read_version = tx.get_version();
+    int set_type = -1;
+    try { set_type = static_cast<int>(graph.storage_.get_set_type(physical, read_version)); }
+    catch (...) {
+      throw_stage("neighbors set_type u=" + std::to_string(u) + " p=" + std::to_string(physical) +
+                  " degree=" + std::to_string(degree) + " version=" + std::to_string(read_version));
+    }
+
+    auto iter = [&]() {
+      try { return tx.neighbourhood_blocked_p(physical); }
+      catch (...) {
+        throw_stage("neighbors iterator-create u=" + std::to_string(u) + " p=" + std::to_string(physical) +
+                    " degree=" + std::to_string(degree) + " type=" + std::to_string(set_type) +
+                    " version=" + std::to_string(read_version));
+      }
+    }();
+
     try {
-      SORTLEDTON_ITERATE(tx, physical, {
-        fn(static_cast<VertexId>(tx.logical_id(make_unversioned(e))));
-      });
-    } catch (...) { throw_stage("neighbors iterate u=" + std::to_string(u)); }
+      while (iter.has_next_block()) {
+        auto [begin, end] = iter.next_block();
+        for (auto it = begin; it < end; ++it) {
+          if (isDeleted(*it)) continue;
+          const auto raw = *it;
+          const auto unversioned = make_unversioned(raw);
+          VertexId logical = 0;
+          try { logical = static_cast<VertexId>(tx.logical_id(unversioned)); }
+          catch (...) {
+            throw_stage("neighbors logical_id u=" + std::to_string(u) + " p=" + std::to_string(physical) +
+                        " raw=" + std::to_string(raw) + " unversioned=" + std::to_string(unversioned));
+          }
+          fn(logical);
+        }
+      }
+    } catch (const std::runtime_error&) {
+      throw;
+    } catch (...) {
+      throw_stage("neighbors iterator-walk u=" + std::to_string(u) + " p=" + std::to_string(physical) +
+                  " degree=" + std::to_string(degree) + " type=" + std::to_string(set_type));
+    }
+
     try { graph.manager_.transactionCompleted(tx); completed = true; }
     catch (...) { throw_stage("neighbors transactionCompleted u=" + std::to_string(u)); }
   } catch (...) {

--- a/benchmarks/external_sortledton_storage_bfs.cpp
+++ b/benchmarks/external_sortledton_storage_bfs.cpp
@@ -1,0 +1,240 @@
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "data-structure/TransactionManager.h"
+#include "data-structure/VersionedBlockedEdgeIterator.h"
+#include "data-structure/VersioningBlockedSkipListAdjacencyList.h"
+#include "velographx/csr_graph.hpp"
+#include "velographx/incremental/bfs.hpp"
+#include "velographx/storage/dynamic_graph.hpp"
+
+namespace sortledton_adapter {
+
+using velographx::UpdateBatch;
+using velographx::VertexId;
+
+class Graph {
+ public:
+  Graph(std::size_t vertices, const std::vector<std::pair<VertexId, VertexId>>& edges)
+      : vertices_(vertices), manager_(1), storage_(512, sizeof(double), manager_) {
+    for (VertexId v = 0; v < vertices_; ++v) {
+      auto tx = manager_.getSnapshotTransaction(&storage_, true);
+      tx.insert_vertex(v);
+      if (!tx.execute()) throw std::runtime_error("Sortledton vertex insertion failed");
+      manager_.transactionCompleted(tx);
+    }
+    for (const auto& [u, v] : edges) insert_edge(u, v);
+  }
+
+  Graph(const Graph&) = delete;
+  Graph& operator=(const Graph&) = delete;
+
+  std::size_t vertices_{0};
+  mutable TransactionManager manager_;
+  mutable VersioningBlockedSkipListAdjacencyList storage_;
+  std::uint64_t version_{0};
+
+  void insert_edge(VertexId u, VertexId v) {
+    auto tx = manager_.getSnapshotTransaction(&storage_, true);
+    const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
+    const double weight = 1.0;
+    tx.insert_edge(edge, reinterpret_cast<const char*>(&weight), sizeof(weight));
+    tx.insert_edge({edge.dst, edge.src}, reinterpret_cast<const char*>(&weight), sizeof(weight));
+    if (!tx.execute()) throw std::runtime_error("Sortledton edge insertion failed");
+    manager_.transactionCompleted(tx);
+  }
+
+  void delete_edge(VertexId u, VertexId v) {
+    auto tx = manager_.getSnapshotTransaction(&storage_, true);
+    const edge_t edge{static_cast<dst_t>(u), static_cast<dst_t>(v)};
+    tx.delete_edge(edge);
+    tx.delete_edge({edge.dst, edge.src});
+    if (!tx.execute()) throw std::runtime_error("Sortledton edge deletion failed");
+    manager_.transactionCompleted(tx);
+  }
+};
+
+std::size_t vx_vertex_count(const Graph& graph) { return graph.vertices_; }
+bool vx_is_directed(const Graph&) { return false; }
+std::uint64_t vx_version(const Graph& graph) { return graph.version_; }
+
+template <class Fn>
+void vx_for_each_neighbor(const Graph& graph, VertexId u, Fn&& fn) {
+  auto tx = graph.manager_.getSnapshotTransaction(&graph.storage_, false);
+  if (!tx.has_vertex(u)) {
+    graph.manager_.transactionCompleted(tx);
+    return;
+  }
+  const auto physical = tx.physical_id(u);
+  auto iter = tx.neighbourhood_blocked_p(physical);
+  while (iter.has_next_block()) {
+    auto [versioned, begin, end] = iter.next_block();
+    if (versioned) {
+      while (iter.has_next_edge()) {
+        const auto dst = iter.next();
+        fn(static_cast<VertexId>(tx.logical_id(dst)));
+      }
+    } else {
+      for (auto it = begin; it < end; ++it) {
+        fn(static_cast<VertexId>(tx.logical_id(*it)));
+      }
+    }
+  }
+  graph.manager_.transactionCompleted(tx);
+}
+
+bool vx_has_edge(const Graph& graph, VertexId u, VertexId v) {
+  auto tx = graph.manager_.getSnapshotTransaction(&graph.storage_, false);
+  const bool result = tx.has_edge(edge_t{static_cast<dst_t>(u), static_cast<dst_t>(v)});
+  graph.manager_.transactionCompleted(tx);
+  return result;
+}
+
+void vx_apply_updates(Graph& graph, const UpdateBatch& batch) {
+  if (batch.empty()) return;
+  for (const auto& op : batch.updates) {
+    if (op.src >= graph.vertices_ || op.dst >= graph.vertices_) continue;
+    const bool exists = vx_has_edge(graph, op.src, op.dst);
+    if (op.add) {
+      if (!exists) graph.insert_edge(op.src, op.dst);
+    } else {
+      if (exists) graph.delete_edge(op.src, op.dst);
+    }
+  }
+  ++graph.version_;
+}
+
+}  // namespace sortledton_adapter
+
+namespace {
+
+using velographx::BasicIncrementalBFS;
+using velographx::CsrGraph;
+using velographx::DynamicGraph;
+using velographx::UpdateBatch;
+using velographx::VertexId;
+
+std::vector<std::pair<VertexId, VertexId>> make_graph(std::size_t vertices) {
+  std::set<std::pair<VertexId, VertexId>> unique;
+  constexpr VertexId offsets[] = {1, 7, 31, 127};
+  for (VertexId u = 0; u < vertices; ++u) {
+    for (auto offset : offsets) {
+      const auto v = static_cast<VertexId>((static_cast<std::size_t>(u) + offset) % vertices);
+      if (u == v) continue;
+      const auto edge = std::minmax(u, v);
+      unique.insert({edge.first, edge.second});
+    }
+  }
+  return {unique.begin(), unique.end()};
+}
+
+std::vector<UpdateBatch> make_incremental_batches(std::size_t vertices) {
+  std::vector<UpdateBatch> batches;
+  batches.reserve(5);
+  for (VertexId i = 0; i < 5; ++i) {
+    UpdateBatch batch;
+    const auto u = static_cast<VertexId>((i * 17) % vertices);
+    const auto ring = static_cast<VertexId>((static_cast<std::size_t>(u) + 1) % vertices);
+    const auto chord = static_cast<VertexId>((static_cast<std::size_t>(u) + 3) % vertices);
+    batch.remove(std::min(u, ring), std::max(u, ring), i * 2);
+    batch.add(std::min(u, chord), std::max(u, chord), i * 2 + 1);
+    batches.push_back(std::move(batch));
+  }
+  return batches;
+}
+
+template <class Graph>
+double median_recompute_us(Graph& graph, VertexId source, std::vector<std::uint32_t>& distances) {
+  BasicIncrementalBFS<Graph> bfs(graph, source);
+  std::vector<double> samples;
+  samples.reserve(5);
+  for (int rep = 0; rep < 5; ++rep) {
+    const auto begin = std::chrono::steady_clock::now();
+    bfs.recompute();
+    const auto end = std::chrono::steady_clock::now();
+    samples.push_back(std::chrono::duration<double, std::micro>(end - begin).count());
+  }
+  std::sort(samples.begin(), samples.end());
+  distances = bfs.distances();
+  return samples[samples.size() / 2];
+}
+
+std::uint64_t digest(const std::vector<std::uint32_t>& distances) {
+  std::uint64_t h = 1469598103934665603ULL;
+  for (auto d : distances) {
+    h ^= static_cast<std::uint64_t>(d);
+    h *= 1099511628211ULL;
+  }
+  return h;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  const std::size_t vertices = argc > 1 ? static_cast<std::size_t>(std::stoull(argv[1])) : 8192;
+  const VertexId source = 0;
+  const auto edges = make_graph(vertices);
+
+  DynamicGraph dynamic(vertices, false);
+  dynamic.bulk_load_edges(edges);
+  CsrGraph csr(edges, false);
+  sortledton_adapter::Graph sortledton_graph(vertices, edges);
+
+  std::vector<std::uint32_t> dynamic_dist, csr_dist, sortledton_dist;
+  const auto dynamic_us = median_recompute_us(dynamic, source, dynamic_dist);
+  const auto csr_us = median_recompute_us(csr, source, csr_dist);
+  const auto sortledton_us = median_recompute_us(sortledton_graph, source, sortledton_dist);
+  const bool recompute_exact = dynamic_dist == csr_dist && dynamic_dist == sortledton_dist;
+
+  BasicIncrementalBFS<DynamicGraph> dynamic_incremental(dynamic, source);
+  BasicIncrementalBFS<sortledton_adapter::Graph> sortledton_incremental(sortledton_graph, source);
+  std::vector<double> dynamic_apply_samples, sortledton_apply_samples;
+  bool incremental_exact = true;
+  for (const auto& batch : make_incremental_batches(vertices)) {
+    auto begin = std::chrono::steady_clock::now();
+    dynamic_incremental.apply(batch);
+    auto end = std::chrono::steady_clock::now();
+    dynamic_apply_samples.push_back(std::chrono::duration<double, std::micro>(end - begin).count());
+
+    begin = std::chrono::steady_clock::now();
+    sortledton_incremental.apply(batch);
+    end = std::chrono::steady_clock::now();
+    sortledton_apply_samples.push_back(std::chrono::duration<double, std::micro>(end - begin).count());
+    incremental_exact = incremental_exact && dynamic_incremental.distances() == sortledton_incremental.distances();
+  }
+  std::sort(dynamic_apply_samples.begin(), dynamic_apply_samples.end());
+  std::sort(sortledton_apply_samples.begin(), sortledton_apply_samples.end());
+  const auto dynamic_apply_us = dynamic_apply_samples[dynamic_apply_samples.size() / 2];
+  const auto sortledton_apply_us = sortledton_apply_samples[sortledton_apply_samples.size() / 2];
+  const bool exact = recompute_exact && incremental_exact;
+
+  std::cout << std::fixed << std::setprecision(3)
+            << "{\"schema_version\":1,"
+            << "\"benchmark\":\"same-algorithm-storage-bfs\","
+            << "\"backend\":\"sortledton\","
+            << "\"algorithm\":\"BasicIncrementalBFS\","
+            << "\"claim_scope\":\"correctness-and-storage-portability-only\","
+            << "\"publication_grade\":false,"
+            << "\"vertices\":" << vertices << ','
+            << "\"edges\":" << edges.size() << ','
+            << "\"source\":" << source << ','
+            << "\"repetitions\":5,"
+            << "\"incremental_batches\":5,"
+            << "\"exact\":" << (exact ? "true" : "false") << ','
+            << "\"recompute_exact\":" << (recompute_exact ? "true" : "false") << ','
+            << "\"incremental_exact\":" << (incremental_exact ? "true" : "false") << ','
+            << "\"digest\":" << digest(dynamic_incremental.distances()) << ','
+            << "\"dynamic_graph_median_us\":" << dynamic_us << ','
+            << "\"csr_graph_median_us\":" << csr_us << ','
+            << "\"sortledton_median_us\":" << sortledton_us << ','
+            << "\"dynamic_incremental_median_us\":" << dynamic_apply_us << ','
+            << "\"sortledton_incremental_median_us\":" << sortledton_apply_us
+            << "}\n";
+  return exact ? 0 : 2;
+}

--- a/tools/materialize_gap_canonical.sh
+++ b/tools/materialize_gap_canonical.sh
@@ -109,7 +109,7 @@ cat > "$OUT/$DATASET.metadata.json" <<JSON
 }
 JSON
 
-sha256sum -c "$OUT/$DATASET.sha256" --ignore-missing
+(cd "$OUT" && sha256sum -c "$DATASET.sha256")
 python - "$OUT/$DATASET.metadata.json" "$DATASET" <<'PY'
 import json, sys
 p, dataset = sys.argv[1:]

--- a/tools/materialize_gap_canonical.sh
+++ b/tools/materialize_gap_canonical.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Materialise one official GAP Benchmark Suite v1.5 corpus graph as plain edge
-# lists so VeloGraphX and GAP consume exactly the same bytes. The graph recipes
-# mirror benchmark/bench.mk; do not reduce -g27/-u27 and call the result canonical.
-
 if [[ $# -ne 3 ]]; then
   echo "usage: $0 <gapbs-source-dir> <twitter|web|road|kron|urand> <output-dir>" >&2
   exit 2
@@ -20,13 +16,17 @@ if [[ ! -x "$GAP_DIR/converter" ]]; then
   make -C "$GAP_DIR" -j2 converter
 fi
 
+GAP_REV=$(git -C "$GAP_DIR" describe --tags --exact-match 2>/dev/null || true)
+if [[ "$GAP_REV" != "v1.5" ]]; then
+  echo "canonical materializer requires GAP Benchmark Suite tag v1.5; got '$GAP_REV'" >&2
+  exit 3
+fi
+
 retry_download() {
   local url=$1
   local path=$2
   for attempt in 1 2 3 4; do
-    if curl -fL --retry 3 --retry-delay 5 "$url" -o "$path"; then
-      return 0
-    fi
+    if curl -fL --retry 3 --retry-delay 5 "$url" -o "$path"; then return 0; fi
     echo "download attempt $attempt failed: $url" >&2
     sleep $((attempt * 5))
   done
@@ -50,6 +50,7 @@ case "$DATASET" in
     retry_download "https://sparse.tamu.edu/MM/LAW/sk-2005.tar.gz" "$archive"
     tar -xzf "$archive" -C "$RAW"
     matrix="$RAW/sk-2005/sk-2005.mtx"
+    test -f "$matrix"
     "$GAP_DIR/converter" -f "$matrix" -e "$OUT/web.el"
     "$GAP_DIR/converter" -f "$matrix" -e "$OUT/web.wel" -w
     ;;
@@ -61,33 +62,67 @@ case "$DATASET" in
     "$GAP_DIR/converter" -f "$RAW/USA-road-d.USA.gr" -e "$OUT/road.wel" -w
     ;;
   kron)
-    # Exact GAP v1.5 benchmark/bench.mk: KRON_ARGS = -g27 -k16
     "$GAP_DIR/converter" -g27 -k16 -e "$OUT/kron.el"
     "$GAP_DIR/converter" -g27 -k16 -e "$OUT/kron.wel" -w
     ;;
   urand)
-    # Exact GAP v1.5 benchmark/bench.mk: URAND_ARGS = -u27 -k16
     "$GAP_DIR/converter" -u27 -k16 -e "$OUT/urand.el"
     "$GAP_DIR/converter" -u27 -k16 -e "$OUT/urand.wel" -w
     ;;
-  *)
-    echo "unknown canonical GAP dataset: $DATASET" >&2
-    exit 2
-    ;;
+  *) echo "unknown canonical GAP dataset: $DATASET" >&2; exit 2 ;;
 esac
 
-sha256sum "$OUT/$DATASET.el" "$OUT/$DATASET.wel" > "$OUT/$DATASET.sha256"
+EDGE_SHA=$(sha256sum "$OUT/$DATASET.el" | awk '{print $1}')
+WEIGHTED_SHA=$(sha256sum "$OUT/$DATASET.wel" | awk '{print $1}')
+printf '%s  %s\n%s  %s\n' "$EDGE_SHA" "$DATASET.el" "$WEIGHTED_SHA" "$DATASET.wel" > "$OUT/$DATASET.sha256"
+EDGE_BYTES=$(stat -c%s "$OUT/$DATASET.el")
+WEIGHTED_BYTES=$(stat -c%s "$OUT/$DATASET.wel")
+
+case "$DATASET" in
+  twitter|web|road) DIRECTED=true ;;
+  kron|urand) DIRECTED=false ;;
+esac
+case "$DATASET" in
+  road) DELTA=50000 ;;
+  *) DELTA=2 ;;
+esac
+
 cat > "$OUT/$DATASET.metadata.json" <<JSON
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "dataset": "$DATASET",
   "gap_revision": "v1.5",
-  "recipe_source": "GAP benchmark/bench.mk",
+  "recipe_source": "GAP Benchmark Suite v1.5 benchmark/bench.mk",
   "canonical": true,
+  "directed": $DIRECTED,
+  "sssp_delta": $DELTA,
   "edge_list": "$DATASET.el",
-  "weighted_edge_list": "$DATASET.wel"
+  "weighted_edge_list": "$DATASET.wel",
+  "checksums": {
+    "edge_list_sha256": "$EDGE_SHA",
+    "weighted_edge_list_sha256": "$WEIGHTED_SHA"
+  },
+  "sizes_bytes": {
+    "edge_list": $EDGE_BYTES,
+    "weighted_edge_list": $WEIGHTED_BYTES
+  }
 }
 JSON
+
+sha256sum -c "$OUT/$DATASET.sha256" --ignore-missing
+python - "$OUT/$DATASET.metadata.json" "$DATASET" <<'PY'
+import json, sys
+p, dataset = sys.argv[1:]
+m = json.load(open(p))
+assert m['schema_version'] == 2
+assert m['dataset'] == dataset
+assert m['gap_revision'] == 'v1.5'
+assert m['canonical'] is True
+assert len(m['checksums']['edge_list_sha256']) == 64
+assert len(m['checksums']['weighted_edge_list_sha256']) == 64
+assert m['sizes_bytes']['edge_list'] > 0
+assert m['sizes_bytes']['weighted_edge_list'] > 0
+PY
 
 echo "materialized canonical GAP dataset: $DATASET"
 cat "$OUT/$DATASET.sha256"

--- a/tools/run_gap_canonical_multiroot.py
+++ b/tools/run_gap_canonical_multiroot.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Run a same-input, same-root VeloGraphX vs GAP BFS/SSSP campaign.
 
-This runner intentionally consumes plain GAP-compatible .el/.wel files. Dataset
-materialisation is kept outside timed regions and the caller records the exact
-GAP upstream recipe/revision used to create them.
+The runner validates dataset semantics and provenance before executing any timing.
+Canonical status is inherited only from a validated materializer metadata file;
+small CI graphs can exercise the same contract but can never become canonical by
+naming convention alone.
 """
 
 import argparse
@@ -15,6 +16,14 @@ import statistics
 import subprocess
 import time
 from pathlib import Path
+
+SEMANTICS = {
+    "twitter": {"directed": True, "sssp_delta": 2},
+    "web": {"directed": True, "sssp_delta": 2},
+    "road": {"directed": True, "sssp_delta": 50000},
+    "kron": {"directed": False, "sssp_delta": 2},
+    "urand": {"directed": False, "sssp_delta": 2},
+}
 
 
 def run(argv, *, env):
@@ -63,9 +72,15 @@ def measure_vx(exe, mode, dataset, source, repeat, threads):
     for _ in range(repeat):
         text, wall = run([str(exe), mode, str(dataset), str(source)], env=env_for_threads(threads))
         row = parse_vx(text)
-        samples.append(row["kernel_us"] / 1_000_000.0)
+        sample = row["kernel_us"] / 1_000_000.0
+        if sample < 0:
+            raise RuntimeError(f"negative VeloGraphX kernel time: {sample}")
+        samples.append(sample)
         digests.append(row["digest"])
         walls.append(wall)
+    stable = len(set(digests)) == 1
+    if not stable:
+        raise RuntimeError(f"VeloGraphX digest changed across repeats: {digests}")
     return {
         "repeat": repeat,
         "source": source,
@@ -74,7 +89,7 @@ def measure_vx(exe, mode, dataset, source, repeat, threads):
         "median_seconds": statistics.median(samples),
         "process_wall_seconds": walls,
         "exact": True,
-        "stable_digest": len(set(digests)) == 1,
+        "stable_digest": True,
         "digest": digests[0],
         "timing_scope": "kernel-only; input construction excluded",
     }
@@ -94,7 +109,10 @@ def measure_gap(exe, algorithm, dataset, source, repeat, threads, delta):
         checks = verification_re.findall(text)
         if len(values) != 1 or checks != ["PASS"]:
             raise RuntimeError(f"unexpected GAP {algorithm} verification output: {text[-4000:]}")
-        samples.append(float(values[0]))
+        sample = float(values[0])
+        if sample < 0:
+            raise RuntimeError(f"negative GAP {algorithm} trial time: {sample}")
+        samples.append(sample)
         walls.append(wall)
     return {
         "repeat": repeat,
@@ -108,16 +126,44 @@ def measure_gap(exe, algorithm, dataset, source, repeat, threads, delta):
     }
 
 
-def parse_int_list(value):
-    return tuple(int(part.strip()) for part in value.split(",") if part.strip())
+def parse_int_list(value, name):
+    try:
+        values = tuple(int(part.strip()) for part in value.split(",") if part.strip())
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be a comma-separated integer list") from exc
+    if not values:
+        raise SystemExit(f"{name} must not be empty")
+    if len(set(values)) != len(values):
+        raise SystemExit(f"{name} must not contain duplicates")
+    return values
+
+
+def validate_metadata(path, args, edge_sha, weighted_sha):
+    if path is None:
+        return {"provided": False, "canonical": False}
+    metadata = json.loads(path.read_text())
+    required = {"schema_version", "dataset", "gap_revision", "canonical", "edge_list", "weighted_edge_list", "checksums"}
+    missing = sorted(required - set(metadata))
+    if missing:
+        raise SystemExit(f"dataset metadata missing fields: {missing}")
+    if metadata["dataset"] != args.dataset_name:
+        raise SystemExit("dataset metadata name does not match --dataset-name")
+    if metadata["gap_revision"] != args.gap_revision:
+        raise SystemExit("dataset metadata GAP revision does not match --gap-revision")
+    if metadata["checksums"].get("edge_list_sha256") != edge_sha:
+        raise SystemExit("edge-list checksum does not match dataset metadata")
+    if metadata["checksums"].get("weighted_edge_list_sha256") != weighted_sha:
+        raise SystemExit("weighted edge-list checksum does not match dataset metadata")
+    return {"provided": True, "canonical": metadata["canonical"], "schema_version": metadata["schema_version"]}
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--output", type=Path, required=True)
-    parser.add_argument("--dataset-name", choices=("twitter", "web", "road", "kron", "urand"), required=True)
+    parser.add_argument("--dataset-name", choices=tuple(SEMANTICS), required=True)
     parser.add_argument("--edge-list", type=Path, required=True)
     parser.add_argument("--weighted-edge-list", type=Path, required=True)
+    parser.add_argument("--dataset-metadata", type=Path)
     parser.add_argument("--velographx", type=Path, required=True)
     parser.add_argument("--gap-bfs", type=Path, required=True)
     parser.add_argument("--gap-sssp", type=Path, required=True)
@@ -129,15 +175,35 @@ def main():
     parser.add_argument("--gap-revision", default="v1.5")
     args = parser.parse_args()
 
-    roots = parse_int_list(args.roots)
-    threads = parse_int_list(args.threads)
+    roots = parse_int_list(args.roots, "--roots")
+    threads = parse_int_list(args.threads, "--threads")
     if len(roots) < 2:
         raise SystemExit("canonical multiroot campaign requires at least two roots")
+    if any(root < 0 for root in roots):
+        raise SystemExit("--roots must be non-negative")
+    if any(thread <= 0 for thread in threads):
+        raise SystemExit("--threads values must be positive")
     if args.repeat < 1:
         raise SystemExit("--repeat must be positive")
-    for path in (args.edge_list, args.weighted_edge_list, args.velographx, args.gap_bfs, args.gap_sssp):
+    if args.sssp_delta <= 0:
+        raise SystemExit("--sssp-delta must be positive")
+
+    expected = SEMANTICS[args.dataset_name]
+    if args.directed != expected["directed"]:
+        raise SystemExit(f"directedness mismatch for {args.dataset_name}: expected {expected['directed']}")
+    if args.sssp_delta != expected["sssp_delta"]:
+        raise SystemExit(f"SSSP delta mismatch for {args.dataset_name}: expected {expected['sssp_delta']}")
+
+    required_paths = [args.edge_list, args.weighted_edge_list, args.velographx, args.gap_bfs, args.gap_sssp]
+    if args.dataset_metadata is not None:
+        required_paths.append(args.dataset_metadata)
+    for path in required_paths:
         if not path.exists():
             raise SystemExit(f"missing required path: {path}")
+
+    edge_sha = sha256(args.edge_list)
+    weighted_sha = sha256(args.weighted_edge_list)
+    provenance = validate_metadata(args.dataset_metadata, args, edge_sha, weighted_sha)
 
     bfs_mode = "bfs-directed" if args.directed else "bfs"
     sssp_mode = "sssp-directed" if args.directed else "sssp"
@@ -164,21 +230,33 @@ def main():
             })
 
     payload = {
-        "schema_version": 1,
+        "schema_version": 2,
         "campaign": "gap-canonical-multiroot",
         "dataset": args.dataset_name,
         "gap_revision": args.gap_revision,
+        "canonical_dataset_result": bool(provenance["canonical"]),
+        "dataset_metadata": provenance,
         "directed": args.directed,
         "roots": roots,
         "threads": threads,
         "repeat": args.repeat,
         "sssp_delta": args.sssp_delta,
         "checksums": {
-            "edge_list_sha256": sha256(args.edge_list),
-            "weighted_edge_list_sha256": sha256(args.weighted_edge_list),
+            "edge_list_sha256": edge_sha,
+            "weighted_edge_list_sha256": weighted_sha,
+        },
+        "input_sizes_bytes": {
+            "edge_list": args.edge_list.stat().st_size,
+            "weighted_edge_list": args.weighted_edge_list.stat().st_size,
         },
         "openmp": {"OMP_PLACES": "cores", "OMP_PROC_BIND": "spread", "OMP_DYNAMIC": "FALSE"},
-        "correctness_gate": "VeloGraphX internal exact oracle and GAP Verification: PASS on every root/repeat",
+        "correctness_gate": {
+            "passed": True,
+            "velographx_internal_exact": True,
+            "velographx_repeat_digest_stable": True,
+            "gap_verification_passed_every_run": True,
+            "same_roots_and_threads": True,
+        },
         "timing_scope": "kernel timers only; dataset materialisation and loading are not mixed into kernel comparison",
         "rows": rows,
     }
@@ -187,6 +265,7 @@ def main():
     print(json.dumps({
         "campaign": payload["campaign"],
         "dataset": args.dataset_name,
+        "canonical_dataset_result": payload["canonical_dataset_result"],
         "roots": len(roots),
         "thread_counts": len(threads),
         "rows": len(rows),


### PR DESCRIPTION
Implements the remaining software-side feedback from the Boost.Graph and LAGraph/GraphBLAS discussions.

- adds a same-algorithm Sortledton adapter pinned to the paper-evaluated revision `6eb638f3ad38f8a10a127e7e118528f4c8d07a6e`
- runs `BasicIncrementalBFS` unchanged over Sortledton with deterministic mixed insert/delete batches and full distance-vector equality gates
- explicitly limits Sortledton output to correctness/storage-portability evidence, not publication-grade performance claims
- hardens canonical GAP materialization metadata, checksums, semantics and revision verification
- makes the multiroot runner fail closed on duplicate/invalid roots or threads, directedness/delta mismatches, unstable digests and checksum/provenance mismatches
- strengthens reduced CI smoke tests while keeping them explicitly non-canonical
- allows canonical evidence only when validated v1.5 materializer metadata and all correctness gates pass
