### PR TITLE
Add canonical publication campaign

### DIFF
--- a/.github/workflows/canonical-publication-campaign.yml
+++ b/.github/workflows/canonical-publication-campaign.yml
@@ -1,0 +1,189 @@
+name: Canonical Publication Campaign
+
+on:
+  push:
+    paths:
+      - 'scripts/run_canonical_dataset_campaign.py'
+      - 'scripts/run_capacity_campaign.py'
+      - 'scripts/prepare_publication_datasets.py'
+      - 'tools/run_controlled_hardware_campaign.py'
+      - 'tools/hardware_campaign_driver.py'
+      - 'tools/run_resource_measurement.py'
+      - 'tools/finalize_canonical_publication_campaign.py'
+      - 'datasets/manifest.publication-canonical.json'
+      - '.github/workflows/canonical-publication-campaign.yml'
+      - 'benchmarks/public_dataset_benchmark.cpp'
+      - 'benchmarks/thread_scaling_bfs.cpp'
+      - 'CMakeLists.txt'
+  workflow_dispatch:
+    inputs:
+      run_controlled:
+        description: 'Run the complete publication campaign on the dedicated runner'
+        required: true
+        default: false
+        type: boolean
+      scales:
+        description: 'Strictly increasing Kronecker/R-MAT scales'
+        required: true
+        default: '16,18,20,22,24,26'
+        type: string
+      edgefactor:
+        description: 'Kronecker/R-MAT edge factor'
+        required: true
+        default: '16'
+        type: string
+      seed:
+        description: 'Kronecker/R-MAT seed'
+        required: true
+        default: '1'
+        type: string
+
+jobs:
+  contract-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Build campaign targets
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DVELOGRAPHX_BUILD_TESTS=OFF -DVELOGRAPHX_BUILD_BENCHMARKS=ON
+          cmake --build build --target velographx_public_dataset_benchmark velographx_thread_scaling_bfs -j2
+      - name: Create checksum-pinned family fixtures
+        run: |
+          python3 - <<'PY'
+          import hashlib, json
+          from pathlib import Path
+          root=Path('smoke-source'); root.mkdir()
+          rows={
+            'web-smoke': '0 1\n1 2\n2 0\n',
+            'social-smoke': '0 1\n1 2\n2 3\n3 0\n',
+            'road-smoke': '0 1\n1 2\n2 3\n',
+          }
+          families={'web-smoke':'scale-free-web','social-smoke':'scale-free-social','road-smoke':'road-network'}
+          entries=[]
+          for name,text in rows.items():
+              path=(root/f'{name}.txt').resolve(); path.write_text(text)
+              entries.append({'name':name,'family':families[name],'url':path.as_uri(),
+                'sha256':hashlib.sha256(path.read_bytes()).hexdigest(),'compression':'none','directed':False,
+                'drop_self_loops':False,'expected_vertices':4 if name != 'web-smoke' else 3,
+                'expected_normalized_rows':len(text.splitlines()),'source':0})
+          Path('smoke-manifest.json').write_text(json.dumps({'schema_version':1,'datasets':entries},indent=2))
+          PY
+      - name: Exercise complete real-dataset harness
+        run: |
+          python3 scripts/run_canonical_dataset_campaign.py \
+            --manifest smoke-manifest.json \
+            --benchmark-binary build/velographx_public_dataset_benchmark \
+            --data-dir smoke-data \
+            --output-dir smoke-artifacts \
+            --repeats 2 --warmups 0 --minimum-repeats 2 --minimum-warmups 0
+      - name: Exercise Kronecker capacity harness
+        run: |
+          python3 scripts/run_capacity_campaign.py \
+            --scales 10,11 --edgefactor 4 --seed 1 \
+            --build-dir build --data-dir smoke-capacity-data --output-dir smoke-capacity
+      - name: Validate final gate closes without controlled hardware
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          Path('smoke-hardware.json').write_text(json.dumps({'hardware_measurement_ready':False,'cases':[]}))
+          PY
+          python3 tools/finalize_canonical_publication_campaign.py \
+            --real smoke-artifacts/canonical-real-summary.json \
+            --capacity smoke-capacity/capacity-summary.json \
+            --hardware smoke-hardware.json \
+            --output smoke-final.json
+          python3 - <<'PY'
+          import json
+          d=json.load(open('smoke-final.json'))
+          assert d['publication_ready'] is False
+          assert d['checks']['controlled_hardware_measurements_valid'] is False
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: canonical-publication-contract-smoke
+          path: |
+            smoke-artifacts/
+            smoke-capacity/
+            smoke-final.json
+          retention-days: 14
+
+  controlled-complete-campaign:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_controlled }}
+    runs-on: [self-hosted, linux, x64, velographx-benchmark]
+    timeout-minutes: 1440
+    env:
+      OMP_PLACES: cores
+      OMP_PROC_BIND: spread
+      VELOGRAPHX_DEDICATED_RUNNER: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify dedicated hardware prerequisites
+        run: |
+          set -euo pipefail
+          test "${RUNNER_ENVIRONMENT:-}" = self-hosted
+          test "$(nproc)" -ge 32
+          command -v numactl
+          command -v perf
+          mkdir -p canonical-artifacts canonical-data capacity-artifacts capacity-data
+          lscpu | tee canonical-artifacts/lscpu.txt
+          numactl --hardware | tee canonical-artifacts/numa.txt
+          free -b | tee canonical-artifacts/memory-before.txt
+      - name: Build release campaign targets
+        run: |
+          cmake -S . -B build-publication -DCMAKE_BUILD_TYPE=Release -DVELOGRAPHX_BUILD_TESTS=ON -DVELOGRAPHX_BUILD_BENCHMARKS=ON
+          cmake --build build-publication -j"$(nproc)"
+          ctest --test-dir build-publication --output-on-failure -j"$(nproc)"
+      - name: Run all canonical real graph families
+        run: |
+          python3 scripts/run_canonical_dataset_campaign.py \
+            --manifest datasets/manifest.publication-canonical.json \
+            --benchmark-binary build-publication/velographx_public_dataset_benchmark \
+            --data-dir canonical-data \
+            --output-dir canonical-artifacts/real \
+            --repeats 10 --warmups 2 --keep-edge-files
+      - name: Run Kronecker/R-MAT series and establish memory boundary
+        run: |
+          python3 scripts/run_capacity_campaign.py \
+            --scales '${{ inputs.scales }}' \
+            --edgefactor '${{ inputs.edgefactor }}' \
+            --seed '${{ inputs.seed }}' \
+            --build-dir build-publication \
+            --data-dir capacity-data \
+            --output-dir capacity-artifacts \
+            --require-boundary
+      - name: Run repeated thread, NUMA, and hardware-counter cases
+        run: |
+          python3 tools/run_controlled_hardware_campaign.py \
+            --output canonical-artifacts/hardware.json \
+            --repeats 10 --warmups 2 \
+            --threads 1,2,4,8,16,32 \
+            --perf --numa --timeout-seconds 1800 -- \
+            build-publication/velographx_thread_scaling_bfs canonical-data/web-Google.edges 64
+      - name: Open publication gate only if every requirement passed
+        run: |
+          python3 tools/finalize_canonical_publication_campaign.py \
+            --real canonical-artifacts/real/canonical-real-summary.json \
+            --capacity capacity-artifacts/capacity-summary.json \
+            --hardware canonical-artifacts/hardware.json \
+            --output canonical-artifacts/canonical-publication-summary.json \
+            --expect-publication-ready
+      - name: Capture final state
+        if: always()
+        run: |
+          free -b | tee canonical-artifacts/memory-after.txt
+          git rev-parse HEAD | tee canonical-artifacts/git-head.txt
+          git status --porcelain | tee canonical-artifacts/git-status.txt
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: canonical-publication-campaign
+          path: |
+            canonical-artifacts/
+            canonical-data/*.metadata.json
+            capacity-artifacts/
+          retention-days: 90

--- a/.github/workflows/dedicated-capacity-campaign.yml
+++ b/.github/workflows/dedicated-capacity-campaign.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'scripts/run_capacity_campaign.py'
       - 'scripts/prepare_publication_datasets.py'
+      - 'tools/run_resource_measurement.py'
       - 'benchmarks/public_dataset_benchmark.cpp'
       - '.github/workflows/dedicated-capacity-campaign.yml'
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Benchmark contracts and interpretation rules: [benchmark methodology](docs/bench
 
 **Current:** hosted CI establishes exactness/reproducibility, 1/2/4-thread engineering behavior, compressed-storage trade-offs, same-run native comparisons and a pinned same-algorithm Teseo storage swap. The refined adaptive selector averages **1.66% overhead from regime-best** on the tested 36 root/regime configurations, but this is not evidence of universal selector optimality. The Teseo experiment isolates one BFS/storage interface on small synthetic graphs and is not a general Teseo performance comparison. Compression saves space but currently slows BFS traversal.
 
-**Next:** held-out graph families and roots for selector generalization; dedicated 8/16/32+ core experiments; true multi-socket NUMA measurements; broader same-machine dynamic-system comparisons; a second external storage adapter such as Sortledton; dedicated NVMe/`io_uring` throughput; hardware counters; broader weighted-dynamic evaluation; a frozen long-term Python API. See [limitations](docs/limitations.md).
+**Next:** execute the [unified canonical publication campaign](docs/canonical-publication-campaign.md) on the dedicated `velographx-benchmark` runner to cover checksum-pinned web/social/road graphs, the complete Kronecker/R-MAT series, the largest clean in-memory boundary, 1/2/4/8/16/32-thread scaling, NUMA placement and hardware counters. Broader same-machine dynamic-system comparisons, dedicated NVMe/`io_uring` throughput, weighted-dynamic evaluation and a frozen long-term Python API remain separate follow-ups. See [limitations](docs/limitations.md).
 
 ## License / Contributing
 

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -17,6 +17,8 @@ A publication-level campaign must cover all of the following families:
 
 The canonical road workload is SNAP `roadNet-CA`: 1,965,206 vertices and 2,766,607 undirected edges in the source dataset. Downloaded bytes must be checksum-pinned by the benchmark campaign before results are accepted.
 
+The complete controlled-hardware manifest is [`manifest.publication-canonical.json`](manifest.publication-canonical.json). It pins `web-Google`, `com-LiveJournal` and `roadNet-CA` by SHA-256 and declares the exact observed vertex/row counts enforced during preparation. The unified runner is documented in [`docs/canonical-publication-campaign.md`](../docs/canonical-publication-campaign.md).
+
 ## Synthetic graph parameters
 
 The default Kronecker/R-MAT contract uses:

--- a/datasets/manifest.publication-canonical.json
+++ b/datasets/manifest.publication-canonical.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "purpose": "Canonical real-dataset inputs for the controlled-hardware publication campaign.",
+  "datasets": [
+    {
+      "name": "web-Google",
+      "family": "scale-free-web",
+      "url": "https://raw.githubusercontent.com/ease-lab/dbg/3737683c0a0bcff6469a4691c16f51425a6bbfd3/datasets/web-Google.txt",
+      "sha256": "8c0f453f1eb1e24ad145e36e542b129083237e96e585abae768927bdb70167d1",
+      "compression": "none",
+      "directed": true,
+      "drop_self_loops": false,
+      "expected_vertices": 875713,
+      "expected_normalized_rows": 5105039,
+      "source": 0
+    },
+    {
+      "name": "com-LiveJournal",
+      "family": "scale-free-social",
+      "url": "https://snap.stanford.edu/data/bigdata/communities/com-lj.ungraph.txt.gz",
+      "sha256": "e0e8996341b963ecbe0a572c71446c03fd6e93a6c521578eaae7566c68ff608e",
+      "compression": "gzip",
+      "directed": false,
+      "drop_self_loops": false,
+      "expected_vertices": 3997962,
+      "expected_normalized_rows": 34681189,
+      "source": 0
+    },
+    {
+      "name": "roadNet-CA",
+      "family": "road-network",
+      "url": "https://snap.stanford.edu/data/roadNet-CA.txt.gz",
+      "sha256": "383f7b14424530a9e25c392969a9c19dace32ebcfd141f0967a1433498c2acdd",
+      "compression": "gzip",
+      "directed": false,
+      "drop_self_loops": true,
+      "expected_vertices": 1965206,
+      "expected_normalized_rows": 5533214,
+      "source": 0
+    }
+  ]
+}

--- a/docs/benchmark-methodology.md
+++ b/docs/benchmark-methodology.md
@@ -31,7 +31,9 @@ Each dedicated-hardware campaign must identify the largest configured graph that
 
 If out-of-memory or external-memory behavior is studied, those results are a separate experiment class and must not be mixed with in-memory numbers.
 
-The executable campaign is `scripts/run_capacity_campaign.py`. It generates deterministic Kronecker workloads, records `/usr/bin/time -v` peak RSS and Linux swap/OOM counters, and only establishes a capacity boundary after at least one clean in-memory success and a larger rejected attempt. The manual `Dedicated Capacity Campaign` workflow targets `[self-hosted, linux, x64, velographx-benchmark]` and invokes the campaign with `--require-boundary`.
+The executable campaign is `scripts/run_capacity_campaign.py`. It generates deterministic Kronecker workloads, records per-process POSIX peak RSS plus Linux swap/OOM counters, and only establishes a capacity boundary after at least one clean in-memory success and a larger rejected attempt. The manual `Dedicated Capacity Campaign` workflow targets `[self-hosted, linux, x64, velographx-benchmark]` and invokes the campaign with `--require-boundary`.
+
+The unified execution entry point is the [canonical publication campaign](canonical-publication-campaign.md). It combines checksum-pinned `web-Google`, `com-LiveJournal` and `roadNet-CA` runs with the Kronecker series, capacity boundary, repeated 1/2/4/8/16/32-thread cases, genuine NUMA placement and hardware counters. Its finalizer opens the publication gate only when every component succeeds on the dedicated runner.
 
 A real workflow-dispatch probe was executed on 2026-08-31 (run `33356427001`). The hosted smoke contract completed successfully, while the `dedicated-boundary` job remained queued without a matching self-hosted runner accepting it. The run was then cancelled and the one-time dispatch probe workflow removed. This confirms that repository-side automation is ready but no usable `velographx-benchmark` runner was available for the publication-capacity measurement at that time. A queued or cancelled run is not publication evidence.
 

--- a/docs/canonical-publication-campaign.md
+++ b/docs/canonical-publication-campaign.md
@@ -1,0 +1,55 @@
+# Canonical publication campaign
+
+The complete controlled-hardware entry point is
+`.github/workflows/canonical-publication-campaign.yml`. It composes the
+previously separate real-dataset, Kronecker capacity, CPU-scaling, NUMA and
+hardware-counter harnesses into one claim-gated artifact.
+
+## Required coverage
+
+The checksum-pinned real-dataset manifest is
+`datasets/manifest.publication-canonical.json`:
+
+| Family | Dataset | Immutable identity |
+|---|---|---|
+| scale-free web | `web-Google` | immutable Git source revision + SHA-256 |
+| scale-free social/community | `com-LiveJournal` | canonical SNAP archive + SHA-256 |
+| road network | `roadNet-CA` | canonical SNAP archive + SHA-256 |
+
+The synthetic campaign uses the documented Graph500-style R-MAT initiator
+`A=0.57, B=0.19, C=0.19, D=0.05`, edge factor 16 by default, a retained seed,
+and scales `16,18,20,22,24,26`. It stops at the first rejected scale. A valid
+capacity result requires both a clean in-memory success and a larger attempted
+scale that fails, swaps, or encounters an OOM event.
+
+## Measurement contract
+
+Each real graph receives two warmups and ten retained end-to-end repetitions.
+Every sample preserves raw CSV output, per-process POSIX resource usage including peak RSS, and result
+signatures. The campaign fails if BFS reachability, component count, triangle
+count, graph size, or PageRank sum changes across repetitions.
+
+The dedicated phase additionally requires:
+
+- a self-hosted runner labelled `velographx-benchmark`;
+- at least 32 allocated CPUs;
+- 1/2/4/8/16/32-thread cases;
+- ten samples and two warmups per controlled case;
+- `perf` hardware-counter collection;
+- genuine NUMA local, interleaved and cross-node cases; and
+- a successful Kronecker in-memory capacity boundary.
+
+`tools/finalize_canonical_publication_campaign.py` opens the publication gate
+only when every required graph family, repetition contract, Kronecker series,
+capacity boundary, controlled-hardware case and hardware-counter case passes.
+Hosted CI exercises the complete artifact plumbing with small fixtures but
+deliberately leaves the publication gate closed.
+
+## Manual dedicated execution
+
+Dispatch **Canonical Publication Campaign** with `run_controlled=true`. The
+workflow retains the final summary, raw samples, dataset metadata, environment,
+machine topology, memory snapshots, capacity records and hardware cases for 90
+days. If the configured largest R-MAT scale still fits, extend the scale list;
+the gate correctly remains closed until a larger rejected attempt establishes
+the capacity boundary.

--- a/scripts/run_canonical_dataset_campaign.py
+++ b/scripts/run_canonical_dataset_campaign.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Run repeated end-to-end measurements over the canonical real datasets.
+
+The input manifest pins every source archive/file by SHA-256 and declares its
+graph family and expected source statistics.  Each measured execution starts
+from the normalized edge list, runs under ``/usr/bin/time -v``, and preserves
+the raw CSV, stderr, and peak-RSS report.  The resulting summary is deliberately
+not a publication claim; the final campaign gate combines it with controlled
+hardware and Kronecker capacity evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gzip
+import hashlib
+import json
+import os
+import platform
+import shutil
+import statistics
+import subprocess
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+REQUIRED_FAMILIES = {"scale-free-web", "scale-free-social", "road-network"}
+SIGNATURE_FIELDS = ("vertices", "edge_entries", "reachable_vertices", "component_count", "triangles")
+TIMING_FIELDS = (
+    "load_us", "bfs_us", "bfs_end_to_end_us", "components_us",
+    "components_end_to_end_us", "triangle_us", "triangle_end_to_end_us",
+    "pagerank_us", "pagerank_end_to_end_us",
+)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def percentile95(values: list[int]) -> int:
+    ordered = sorted(values)
+    return ordered[min(len(ordered) - 1, int(0.95 * (len(ordered) - 1) + 0.5))]
+
+
+def capture(command: list[str]) -> str:
+    try:
+        return subprocess.check_output(command, text=True, stderr=subprocess.STDOUT).strip()
+    except Exception as exc:  # noqa: BLE001 - metadata collection must remain diagnostic
+        return f"unavailable: {exc}"
+
+
+def prepare_dataset(entry: dict, data_dir: Path) -> tuple[Path, dict]:
+    name = entry["name"]
+    expected_hash = entry["sha256"]
+    if len(expected_hash) != 64 or any(c not in "0123456789abcdef" for c in expected_hash):
+        raise ValueError(f"{name}: invalid SHA-256 pin")
+
+    suffix = ".txt.gz" if entry.get("compression") == "gzip" else ".txt"
+    source = data_dir / f"{name}{suffix}"
+    normalized = data_dir / f"{name}.edges"
+    if not source.exists():
+        with urllib.request.urlopen(entry["url"]) as response, source.open("wb") as output:
+            shutil.copyfileobj(response, output)
+    actual_hash = sha256_file(source)
+    if actual_hash != expected_hash:
+        source.unlink(missing_ok=True)
+        raise RuntimeError(f"{name}: source SHA-256 mismatch: expected {expected_hash}, got {actual_hash}")
+
+    opener = gzip.open if entry.get("compression") == "gzip" else open
+    vertices: set[int] = set()
+    rows = 0
+    with opener(source, "rt", encoding="utf-8") as src, normalized.open("w", encoding="utf-8") as dst:
+        for line in src:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            fields = stripped.split()
+            if len(fields) < 2:
+                raise RuntimeError(f"{name}: malformed edge row {rows + 1}")
+            u, v = int(fields[0]), int(fields[1])
+            if u == v and entry.get("drop_self_loops", True):
+                continue
+            dst.write(f"{u} {v}\n")
+            vertices.add(u)
+            vertices.add(v)
+            rows += 1
+
+    expected_rows = int(entry["expected_normalized_rows"])
+    expected_vertices = int(entry["expected_vertices"])
+    if rows != expected_rows or len(vertices) != expected_vertices:
+        raise RuntimeError(
+            f"{name}: normalized statistics mismatch: vertices={len(vertices)} rows={rows}; "
+            f"expected vertices={expected_vertices} rows={expected_rows}"
+        )
+    metadata = {
+        "name": name,
+        "family": entry["family"],
+        "directed": bool(entry["directed"]),
+        "source_url": entry["url"],
+        "source_sha256": actual_hash,
+        "normalized_sha256": sha256_file(normalized),
+        "vertices_observed": len(vertices),
+        "normalized_rows_observed": rows,
+    }
+    (data_dir / f"{name}.metadata.json").write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+    return normalized, metadata
+
+
+def read_benchmark_row(path: Path) -> dict[str, str]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    if len(rows) != 1:
+        raise RuntimeError(f"expected exactly one benchmark row in {path}, got {len(rows)}")
+    return rows[0]
+
+
+def run_sample(binary: Path, edge_list: Path, source: int, output_dir: Path, label: str, keep: bool) -> dict:
+    csv_path = output_dir / f"{label}.csv"
+    stderr_path = output_dir / f"{label}.stderr.txt"
+    resource_path = output_dir / f"{label}.resources.json"
+    helper = Path(__file__).resolve().parents[1] / "tools" / "run_resource_measurement.py"
+    command = [sys.executable, str(helper), "--output", str(resource_path), "--", str(binary), str(edge_list), str(source)]
+    with csv_path.open("w", encoding="utf-8") as stdout, stderr_path.open("w", encoding="utf-8") as stderr:
+        completed = subprocess.run(command, text=True, stdout=stdout, stderr=stderr, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(f"benchmark failed ({completed.returncode}); see {stderr_path}")
+    row = read_benchmark_row(csv_path)
+    resource_report = json.loads(resource_path.read_text(encoding="utf-8"))
+    sample = {
+        "label": label,
+        "resource_measurement": resource_report,
+        "peak_rss_bytes": int(resource_report["peak_rss_bytes"]),
+        "signature": {field: row[field] for field in SIGNATURE_FIELDS},
+        "pagerank_sum": float(row["pagerank_sum"]),
+        "timings_us": {field: int(row[field]) for field in TIMING_FIELDS},
+    }
+    if not keep:
+        csv_path.unlink(missing_ok=True)
+        stderr_path.unlink(missing_ok=True)
+        resource_path.unlink(missing_ok=True)
+    return sample
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run checksum-pinned canonical real-dataset campaign")
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--benchmark-binary", type=Path, required=True)
+    parser.add_argument("--data-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--repeats", type=int, default=10)
+    parser.add_argument("--warmups", type=int, default=2)
+    parser.add_argument("--minimum-repeats", type=int, default=10)
+    parser.add_argument("--minimum-warmups", type=int, default=2)
+    parser.add_argument("--keep-edge-files", action="store_true")
+    parser.add_argument("--keep-warmups", action="store_true")
+    args = parser.parse_args()
+
+    if args.repeats < 1 or args.warmups < 0 or args.minimum_repeats < 1 or args.minimum_warmups < 0:
+        raise ValueError("repeat/warmup values must be positive/non-negative")
+    binary = args.benchmark_binary.resolve()
+    if not binary.is_file():
+        raise ValueError(f"benchmark binary not found: {binary}")
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    if manifest.get("schema_version") != 1:
+        raise ValueError("unsupported manifest schema_version")
+    datasets = manifest.get("datasets")
+    if not isinstance(datasets, list) or not datasets:
+        raise ValueError("manifest datasets must be a non-empty list")
+    families = {entry.get("family") for entry in datasets}
+    if not REQUIRED_FAMILIES.issubset(families):
+        raise ValueError(f"manifest missing required families: {sorted(REQUIRED_FAMILIES - families)}")
+
+    args.data_dir.mkdir(parents=True, exist_ok=True)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    environment = {
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "git_head": capture(["git", "rev-parse", "HEAD"]),
+        "git_status": capture(["git", "status", "--porcelain"]),
+        "platform": platform.platform(),
+        "hostname": platform.node(),
+        "python": sys.version,
+        "lscpu": capture(["lscpu"]),
+        "numactl": capture(["numactl", "--hardware"]) if shutil.which("numactl") else "numactl unavailable",
+        "memory": Path("/proc/meminfo").read_text(encoding="utf-8") if Path("/proc/meminfo").exists() else "unavailable",
+        "thread_environment": {key: os.environ.get(key) for key in ("OMP_NUM_THREADS", "OMP_PLACES", "OMP_PROC_BIND")},
+        "repeats": args.repeats,
+        "warmups": args.warmups,
+    }
+    (args.output_dir / "environment.json").write_text(json.dumps(environment, indent=2) + "\n", encoding="utf-8")
+
+    results = []
+    for entry in datasets:
+        edge_list, metadata = prepare_dataset(entry, args.data_dir)
+        source = int(entry.get("source", 0))
+        for index in range(args.warmups):
+            run_sample(binary, edge_list, source, args.output_dir, f"{entry['name']}.warmup-{index + 1}", args.keep_warmups)
+        samples = [
+            run_sample(binary, edge_list, source, args.output_dir, f"{entry['name']}.sample-{index + 1}", True)
+            for index in range(args.repeats)
+        ]
+        expected_signature = samples[0]["signature"]
+        if any(sample["signature"] != expected_signature for sample in samples):
+            raise RuntimeError(f"{entry['name']}: deterministic result signature mismatch")
+        rank_sums = [sample["pagerank_sum"] for sample in samples]
+        if max(rank_sums) - min(rank_sums) > 1e-9:
+            raise RuntimeError(f"{entry['name']}: PageRank result changed across repetitions")
+        timing_summary = {}
+        for field in TIMING_FIELDS:
+            values = [sample["timings_us"][field] for sample in samples]
+            timing_summary[field] = {
+                "median": statistics.median(values),
+                "p95": percentile95(values),
+                "min": min(values),
+                "max": max(values),
+            }
+        results.append({
+            "dataset": metadata,
+            "source": source,
+            "repeats": args.repeats,
+            "warmups": args.warmups,
+            "all_samples_consistent": True,
+            "signature": expected_signature,
+            "pagerank_sum": rank_sums[0],
+            "peak_rss_bytes": {
+                "median": statistics.median(sample["peak_rss_bytes"] for sample in samples),
+                "max": max(sample["peak_rss_bytes"] for sample in samples),
+            },
+            "timing_summary_us": timing_summary,
+            "samples": samples,
+        })
+        if not args.keep_edge_files:
+            edge_list.unlink(missing_ok=True)
+
+    summary = {
+        "schema_version": 1,
+        "artifact_type": "velographx-canonical-real-dataset-campaign",
+        "research_claim": False,
+        "publication_ready": False,
+        "required_families": sorted(REQUIRED_FAMILIES),
+        "covered_families": sorted(families),
+        "minimum_repeats_met": args.repeats >= args.minimum_repeats,
+        "minimum_warmups_met": args.warmups >= args.minimum_warmups,
+        "all_results_consistent": all(item["all_samples_consistent"] for item in results),
+        "results": results,
+    }
+    summary["canonical_real_dataset_gate_passed"] = bool(
+        summary["minimum_repeats_met"] and summary["minimum_warmups_met"] and summary["all_results_consistent"]
+    )
+    (args.output_dir / "canonical-real-summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "output": str(args.output_dir / "canonical-real-summary.json"),
+        "datasets": [entry["name"] for entry in datasets],
+        "canonical_real_dataset_gate_passed": summary["canonical_real_dataset_gate_passed"],
+    }, sort_keys=True))
+    return 0 if summary["canonical_real_dataset_gate_passed"] else 3
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(2)

--- a/scripts/run_capacity_campaign.py
+++ b/scripts/run_capacity_campaign.py
@@ -2,7 +2,7 @@
 """Run the publication-grade in-memory capacity boundary campaign.
 
 The sweep generates deterministic Kronecker workloads, executes the public
-benchmark under /usr/bin/time -v, records peak RSS and Linux swap activity,
+benchmark under a per-process POSIX resource wrapper, records peak RSS and Linux swap activity,
 and stops at the first scale that cannot complete as a clean in-memory run.
 
 A capacity boundary is established only when at least one scale succeeds and a
@@ -50,25 +50,6 @@ def read_vmstat() -> dict[str, int]:
     return values
 
 
-def parse_time_verbose(path: Path) -> dict[str, int | str]:
-    result: dict[str, int | str] = {}
-    if not path.exists():
-        return result
-    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-        if ":" not in line:
-            continue
-        key, value = line.split(":", 1)
-        key = key.strip()
-        value = value.strip()
-        if key == "Maximum resident set size (kbytes)":
-            result["peak_rss_bytes"] = int(value) * 1024
-        elif key == "Elapsed (wall clock) time (h:mm:ss or m:ss)":
-            result["elapsed_wall"] = value
-        elif key == "Exit status":
-            result["time_exit_status"] = int(value)
-    return result
-
-
 def capture_command(command: list[str]) -> str:
     try:
         return subprocess.check_output(command, text=True, stderr=subprocess.STDOUT).strip()
@@ -100,6 +81,7 @@ def main() -> int:
 
     root = Path(__file__).resolve().parents[1]
     prepare_script = root / "scripts" / "prepare_publication_datasets.py"
+    resource_helper = root / "tools" / "run_resource_measurement.py"
     benchmark = args.benchmark_binary or (args.build_dir / "velographx_public_dataset_benchmark")
     benchmark = benchmark.resolve()
     args.data_dir.mkdir(parents=True, exist_ok=True)
@@ -107,8 +89,8 @@ def main() -> int:
 
     if not benchmark.exists():
         raise SystemExit(f"benchmark binary not found: {benchmark}")
-    if shutil.which("/usr/bin/time") is None and not Path("/usr/bin/time").exists():
-        raise SystemExit("/usr/bin/time is required for publication-grade peak RSS capture")
+    if not resource_helper.is_file():
+        raise SystemExit(f"resource measurement helper not found: {resource_helper}")
 
     environment = {
         "timestamp_utc": datetime.now(timezone.utc).isoformat(),
@@ -147,7 +129,7 @@ def main() -> int:
         prepare_log = args.output_dir / f"{prefix}.prepare.log"
         csv_path = args.output_dir / f"{prefix}.csv"
         stderr_path = args.output_dir / f"{prefix}.stderr.txt"
-        time_path = args.output_dir / f"{prefix}.time.txt"
+        resource_path = args.output_dir / f"{prefix}.resources.json"
 
         prepare_cmd = [
             sys.executable,
@@ -191,10 +173,11 @@ def main() -> int:
         mem_before = read_meminfo()
 
         command = [
-            "/usr/bin/time",
-            "-v",
-            "-o",
-            str(time_path),
+            sys.executable,
+            str(resource_helper),
+            "--output",
+            str(resource_path),
+            "--",
             str(benchmark),
             str(edge_path),
             str(args.source),
@@ -204,7 +187,7 @@ def main() -> int:
 
         vm_after = read_vmstat()
         mem_after = read_meminfo()
-        timing = parse_time_verbose(time_path)
+        timing = json.loads(resource_path.read_text(encoding="utf-8")) if resource_path.exists() else {}
         swapin_delta = vm_after.get("pswpin", 0) - vm_before.get("pswpin", 0)
         swapout_delta = vm_after.get("pswpout", 0) - vm_before.get("pswpout", 0)
         oom_delta = vm_after.get("oom_kill", 0) - vm_before.get("oom_kill", 0)
@@ -214,7 +197,7 @@ def main() -> int:
             {
                 "benchmark_exit_code": completed.returncode,
                 "peak_rss_bytes": timing.get("peak_rss_bytes"),
-                "elapsed_wall": timing.get("elapsed_wall"),
+                "elapsed_wall_seconds": timing.get("wall_seconds"),
                 "pswpin_pages_delta": swapin_delta,
                 "pswpout_pages_delta": swapout_delta,
                 "oom_kill_delta": oom_delta,

--- a/tools/finalize_canonical_publication_campaign.py
+++ b/tools/finalize_canonical_publication_campaign.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Combine canonical real, Kronecker capacity, and hardware evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--real", type=Path, required=True)
+    parser.add_argument("--capacity", type=Path, required=True)
+    parser.add_argument("--hardware", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--expect-publication-ready", action="store_true")
+    args = parser.parse_args()
+
+    real = json.loads(args.real.read_text(encoding="utf-8"))
+    capacity = json.loads(args.capacity.read_text(encoding="utf-8"))
+    hardware = json.loads(args.hardware.read_text(encoding="utf-8"))
+    checks = {
+        "scale_free_web_covered": "scale-free-web" in real.get("covered_families", []),
+        "scale_free_social_covered": "scale-free-social" in real.get("covered_families", []),
+        "road_network_covered": "road-network" in real.get("covered_families", []),
+        "real_dataset_repetitions_valid": real.get("canonical_real_dataset_gate_passed") is True,
+        "kronecker_series_executed": len(capacity.get("records", [])) >= 2,
+        "largest_in_memory_boundary_established": capacity.get("boundary_established") is True,
+        "controlled_hardware_measurements_valid": hardware.get("hardware_measurement_ready") is True,
+        "hardware_counter_case_present": any(case.get("kind") == "hardware_counters" for case in hardware.get("cases", [])),
+    }
+    ready = all(checks.values())
+    report = {
+        "schema_version": 1,
+        "artifact_type": "velographx-canonical-publication-campaign",
+        "research_claim": ready,
+        "publication_ready": ready,
+        "allow_publication_claims": ready,
+        "checks": checks,
+        "real_dataset_summary": str(args.real),
+        "capacity_summary": str(args.capacity),
+        "hardware_summary": str(args.hardware),
+        "largest_accepted_kronecker_scale": capacity.get("largest_accepted_scale"),
+        "first_rejected_kronecker_scale": capacity.get("first_rejected_scale"),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(report, sort_keys=True))
+    if args.expect_publication_ready and not ready:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/hardware_campaign_driver.py
+++ b/tools/hardware_campaign_driver.py
@@ -9,6 +9,21 @@ import sys
 import time
 
 
+def allocated_cpu_ids():
+    if hasattr(os, "sched_getaffinity"):
+        try:
+            cpus = sorted(os.sched_getaffinity(0))
+            if cpus:
+                return cpus
+        except OSError:
+            pass
+    return list(range(max(1, os.cpu_count() or 1)))
+
+
+def format_cpu_list(cpus):
+    return ",".join(str(cpu) for cpu in cpus)
+
+
 def build_command(args):
     command = list(args.command)
     wrappers = []
@@ -18,7 +33,10 @@ def build_command(args):
             raise ValueError("--threads must be at least 1")
         taskset = shutil.which("taskset")
         if taskset:
-            wrappers += [taskset, "-c", f"0-{args.threads - 1}"]
+            allocation = allocated_cpu_ids()
+            if args.threads > len(allocation):
+                raise ValueError(f"requested {args.threads} threads but only {len(allocation)} CPUs are allocated")
+            wrappers += [taskset, "-c", format_cpu_list(allocation[:args.threads])]
 
     if args.numa_policy != "none":
         numactl = shutil.which("numactl")

--- a/tools/run_resource_measurement.py
+++ b/tools/run_resource_measurement.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Run one command and record per-process POSIX resource usage as JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import resource
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = args.command[1:] if args.command and args.command[0] == "--" else args.command
+    if not command:
+        raise ValueError("command is required after --")
+    started = time.perf_counter()
+    completed = subprocess.run(command, check=False)
+    elapsed = time.perf_counter() - started
+    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    # Linux reports ru_maxrss in KiB; macOS/BSD report bytes.
+    peak_rss_bytes = int(usage.ru_maxrss) * (1024 if sys.platform.startswith("linux") else 1)
+    report = {
+        "schema_version": 1,
+        "argv": command,
+        "returncode": completed.returncode,
+        "wall_seconds": elapsed,
+        "peak_rss_bytes": peak_rss_bytes,
+        "user_cpu_seconds": usage.ru_utime,
+        "system_cpu_seconds": usage.ru_stime,
+        "minor_page_faults": usage.ru_minflt,
+        "major_page_faults": usage.ru_majflt,
+        "voluntary_context_switches": usage.ru_nvcsw,
+        "involuntary_context_switches": usage.ru_nivcsw,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add one checksum-pinned canonical real-dataset campaign covering web-Google, com-LiveJournal, and roadNet-CA
- integrate the deterministic Kronecker/R-MAT series and largest clean in-memory capacity boundary
- require 1/2/4/8/16/32-thread, NUMA, and hardware-counter evidence on a dedicated self-hosted runner
- add a fail-closed final evidence gate and update the benchmark documentation

## Validation
- direct C++20 release compilation of the public-dataset and thread-scaling benchmarks
- full one-pass engineering run on all three pinned real datasets
- LiveJournal triangle result matched the known 177,820,130 count
- Python syntax checks for all changed campaign tools
- local Kronecker scale 10/11 capacity smoke
- hardware-affinity and controlled-campaign smoke
- workflow YAML parsing and git diff checks

The push-triggered contract job performs the authoritative CMake build and smoke validation. Publication claims remain closed unless the dedicated `velographx-benchmark` job completes every required gate.