### PR TITLE
Synchronize roadmap and competitor evidence status

### DIFF
--- a/.github/workflows/public-dataset-plan.yml
+++ b/.github/workflows/public-dataset-plan.yml
@@ -40,9 +40,9 @@ jobs:
           from pathlib import Path
           report = json.loads(Path('build/competitor-plan.json').read_text())
           assert report['valid'] is True
-          assert report['competitor_count'] == 8
-          assert report['ready_count'] == 1
-          assert report['unresolved_count'] == 7
+          assert report['competitor_count'] == 9
+          assert report['ready_count'] == 6
+          assert report['unresolved_count'] == 3
           assert report['publication_ready'] is False
           PY
       - name: Reject floating competitor version pins

--- a/benchmarks/competitor-research-plan.json
+++ b/benchmarks/competitor-research-plan.json
@@ -30,9 +30,19 @@
       "version_or_commit": "2c37c2831c4d2acaaa838a86e1318363ce68c45b",
       "source": "https://github.com/cwida/teseo",
       "license": "GPL-3.0",
-      "install_or_build_recipe": null,
-      "comparison_scope": "Structural dynamic-graph update/scan behavior only; do not compare Teseo storage operations with VeloGraphX incremental algorithm repair as if they were the same operation.",
-      "ready": false
+      "install_or_build_recipe": ".github/workflows/external-teseo-storage.yml",
+      "comparison_scope": "Correctness-gated same-algorithm storage swap using BasicIncrementalBFS recomputation and mixed insertion/deletion batches; not a comparison with Teseo native algorithms or a system-level performance claim.",
+      "ready": true
+    },
+    {
+      "name": "Sortledton",
+      "kind": "native-dynamic-graph-storage-system",
+      "version_or_commit": "6eb638f3ad38f8a10a127e7e118528f4c8d07a6e",
+      "source": "https://gitlab.db.in.tum.de/per.fuchs/sortledton",
+      "license": "upstream repository terms",
+      "install_or_build_recipe": ".github/workflows/external-sortledton-storage.yml",
+      "comparison_scope": "Correctness-gated same-algorithm storage portability using BasicIncrementalBFS recomputation and deterministic mixed insertion/deletion batches; hosted timings are diagnostic only.",
+      "ready": true
     },
     {
       "name": "NetworkX",
@@ -55,11 +65,11 @@
     {
       "name": "NetworKit",
       "kind": "python-package-native-core",
-      "version_or_commit": null,
+      "version_or_commit": "359f3fbf09b6d3fe214db24dd01bc8bfc1c2653c",
       "source": "https://github.com/networkit/networkit",
-      "install_or_build_recipe": null,
-      "comparison_scope": "Algorithm-specific; require matched update and correctness semantics.",
-      "ready": false
+      "install_or_build_recipe": ".github/workflows/external-networkit-native-multidataset.yml",
+      "comparison_scope": "Native NetworKit::DynBFS versus VeloGraphX exact directed dynamic BFS on identical streams, batches and three fixed roots per dataset, with full-BFS verification after every batch.",
+      "ready": true
     },
     {
       "name": "rustworkx",
@@ -73,20 +83,21 @@
     {
       "name": "SuiteSparse:GraphBLAS/LAGraph",
       "kind": "native",
-      "version_or_commit": null,
+      "version_or_commit": "d01064de77b606473744b99f63b1487963556194",
       "source": "https://github.com/DrTimothyAldenDavis/GraphBLAS + https://github.com/GraphBLAS/LAGraph",
-      "install_or_build_recipe": "docs/native-competitors.md",
-      "comparison_scope": "Static/full graph analytics unless a matched dynamic algorithm is available.",
-      "ready": false
+      "graphblas_version": "v10.5.0",
+      "install_or_build_recipe": ".github/workflows/hosted-native-competitors.yml",
+      "comparison_scope": "Correctness-gated hosted BFS/SSSP engineering comparison using pinned GraphBLAS/LAGraph builds; dedicated-hardware publication execution remains outstanding.",
+      "ready": true
     },
     {
       "name": "GAP Benchmark Suite",
       "kind": "native",
-      "version_or_commit": null,
+      "version_or_commit": "v1.5",
       "source": "https://github.com/sbeamer/gapbs",
-      "install_or_build_recipe": "docs/native-competitors.md",
-      "comparison_scope": "Static/full graph analytics only.",
-      "ready": false
+      "install_or_build_recipe": ".github/workflows/hosted-native-competitors.yml",
+      "comparison_scope": "Correctness-gated hosted BFS/SSSP engineering comparison using GAP verification; official canonical GAP datasets and dedicated-hardware publication execution remain separate gates.",
+      "ready": true
     }
   ],
   "rules": [
@@ -98,5 +109,5 @@
     "Do not remove deletions, validation, or other difficult workload features merely because they disadvantage VeloGraphX.",
     "Hosted CI results are engineering evidence and must not be described as universal or publication-grade performance claims."
   ],
-  "notes": "RisGraph is the first pinned same-semantics dynamic-system baseline. Teseo is pinned as a screened storage candidate but remains ineligible for a promoted comparison until a separate matched storage harness is established."
+  "notes": "Ready means the immutable identity, build recipe and stated comparison contract are executable; it does not imply publication-grade evidence. RisGraph and NetworKit are accepted same-semantics dynamic-BFS baselines. Teseo and Sortledton are ready only for explicitly labelled same-algorithm storage portability/correctness experiments. GAP and LAGraph have successful hosted engineering campaigns, while dedicated-hardware publication execution remains outstanding."
 }

--- a/docs/competitor-benchmarking.md
+++ b/docs/competitor-benchmarking.md
@@ -69,6 +69,6 @@ The result digest is intended for correctness comparison across implementations.
 
 ## Measurement discipline
 
-The builtin adapter and mock external adapter are test references, not performance competitors. NetworkX, igraph, NetworKit and rustworkx results should be produced in a pinned benchmark environment and their package versions retained in every report. GAP and SuiteSparse:GraphBLAS/LAGraph can now be integrated through the external contract, but actual native wrapper implementations, pinned native builds and measured results remain future benchmark-environment work.
+The builtin adapter and mock external adapter are test references, not performance competitors. NetworkX, igraph, NetworKit and rustworkx results should be produced in a pinned benchmark environment and their package versions retained in every report. The generic external contract remains available for locally installed systems. In addition, `.github/workflows/hosted-native-competitors.yml` now builds pinned SuiteSparse:GraphBLAS/LAGraph and GAP sources and executes correctness-gated BFS/SSSP measurements; `.github/workflows/external-networkit-native-multidataset.yml` performs the matched native dynamic-BFS campaign. These hosted results are engineering evidence, not substitutes for the dedicated canonical-dataset campaign.
 
 Large-scale benchmark claims remain unmeasured until the documented campaign is run on dedicated hardware.

--- a/docs/hosted-native-competitors.md
+++ b/docs/hosted-native-competitors.md
@@ -10,6 +10,8 @@ This workflow implements the native BFS/SSSP methodology recommended by Prof. Ti
 
 Exact resolved commits are retained with every artifact. Hosted evidence remains `research_claim: false` and `publication_grade: false`.
 
+Accepted hosted evidence: GitHub Actions run `33418520303`, artifact `9768499895`. The retained campaign passed the cross-engine correctness gates for BFS, SSSP and dynamic snapshots and is summarized in the README. It is the current hosted engineering result, not a dedicated-hardware publication result.
+
 ## Davis methodology applied
 
 The campaign follows these rules:

--- a/docs/native-competitor-benchmarks.md
+++ b/docs/native-competitor-benchmarks.md
@@ -1,6 +1,6 @@
 # Native competitor benchmark recipes
 
-VeloGraphX normalizes native competitors through `tools/competitor_benchmark.py --framework external`. The repository includes shims for SuiteSparse:GraphBLAS/LAGraph and the GAP Benchmark Suite, but it deliberately does not vendor or pretend to install those native projects. Their versions, compiler flags, threading configuration, and ABI details are part of the benchmark environment and must be recorded with the final results.
+VeloGraphX normalizes native competitors through `tools/competitor_benchmark.py --framework external`. The repository includes shims for SuiteSparse:GraphBLAS/LAGraph and the GAP Benchmark Suite and does not vendor those projects. For hosted engineering evidence, `.github/workflows/hosted-native-competitors.yml` clones immutable revisions, builds them from source and records versions, compiler flags and threading configuration with the artifact. Dedicated environments must still provide and record their own installations through the normalized contract.
 
 ## Common runner contract
 

--- a/docs/native-competitors.md
+++ b/docs/native-competitors.md
@@ -1,6 +1,8 @@
 # Native competitor adapters
 
-VeloGraphX keeps heavyweight native competitors behind the normalized external benchmark contract so results can be gathered on dedicated machines without making GitHub-hosted CI depend on system-specific GraphBLAS/LAGraph or GAP installations.
+VeloGraphX keeps heavyweight native competitors behind a normalized external benchmark contract for dedicated-machine execution. A separate hosted evidence workflow also builds immutable GraphBLAS/LAGraph and GAP revisions from source, runs their native BFS/SSSP programs and retains correctness-gated engineering artifacts. Hosted measurements do not replace the normalized dedicated-hardware contract below.
+
+See [`hosted-native-competitors.md`](hosted-native-competitors.md) for the completed hosted campaign and [`gap-canonical-multiroot.md`](gap-canonical-multiroot.md) for the official GAP-dataset path.
 
 ## Contract
 

--- a/docs/normalized-native-bfs.md
+++ b/docs/normalized-native-bfs.md
@@ -28,8 +28,8 @@ The existing shims are:
 - `tools/native_competitors/lagraph_wrapper.py`
 - `tools/native_competitors/gap_wrapper.py`
 
-## Remaining implementation
+## Current execution status
 
-The hosted workflow still needs native runner binaries that expose full BFS distance vectors from the pinned LAGraph/GraphBLAS and GAP implementations. Once those runners are wired in, the normalization validator becomes the mandatory correctness gate before any cross-engine timing summary is emitted.
+The repository now has two complementary native paths. The normalized external-command validator remains the mandatory portable contract for dedicated environments that provide full distance-vector runners. Separately, `.github/workflows/hosted-native-competitors.yml` builds pinned GraphBLAS/LAGraph and GAP sources and executes their native benchmark programs with independent self-checks and matched VeloGraphX verification. The hosted path records native pins, raw repetitions and timing scopes, but remains engineering evidence rather than publication-grade execution.
 
 Publication-grade competitor claims remain blocked until the same normalized contract is executed on the dedicated hardware campaign required by Issue #10.

--- a/docs/prompt-coverage.md
+++ b/docs/prompt-coverage.md
@@ -23,10 +23,14 @@ This document maps the repository against the original VeloGraphX implementation
 - Checksum-verified dataset preparation tooling with local fixture coverage and explicit SHA-256 mismatch validation.
 - Competitor benchmark adapters for builtin reference, NetworkX, igraph, NetworKit and rustworkx, plus a normalized external/native command contract.
 - Concrete native adapter shims and reproducibility recipes for locally installed SuiteSparse:GraphBLAS/LAGraph and GAP BFS runners, with deterministic contract fixtures and explicit failure when native binaries are unavailable.
+- Successful pinned hosted-native BFS/SSSP execution against SuiteSparse:GraphBLAS `v10.5.0`, LAGraph commit `d01064de77b606473744b99f63b1487963556194` and GAP `v1.5`, with five repetitions, exactness gates and separately labelled kernel/process-wall timing.
+- Pinned same-algorithm storage-portability workflows for Teseo, Boost.Graph and Sortledton, including recomputation and deterministic mixed-update correctness gates.
+- Native NetworKit 11.2.1 dynamic-BFS comparison across the same three fixed roots on both `web-Google` and `ca-GrQc`, five paired repetitions per root and exact full-BFS verification for all 30 pairs.
 - Reproducible machine-readable experiment orchestration and campaign definitions for update-fraction crossover, thread scaling, NUMA placement, hardware counters and ablations.
 - Codec throughput/compression-ratio benchmark tooling across dense, medium and sparse graph-neighbor families, including scalar versus vectorized fixed-width decode measurements.
 - Codec-policy calibration tooling that derives machine-readable thresholds from supplied benchmark CSV while explicitly separating synthetic/self-test data from research claims.
 - CI on Ubuntu/macOS, ASan/UBSan, observability structures, ablation suite, paper scaffold and benchmark tooling.
+- Hosted 10M/100M storage A/B evidence plus 100M+-class `com-Orkut` steady-state/canonicalization evidence, with explicit engineering-only claim gates.
 
 ## Partial — implementation exists but original prompt requires deeper capability or validation
 
@@ -35,15 +39,15 @@ This document maps the repository against the original VeloGraphX implementation
 - Python interoperability covers the major dynamic/incremental algorithms implemented by the engine; additional convenience APIs and future algorithms can still be exposed as they are added.
 - Out-of-core storage supports mmap, async loading, bounded caching, readahead and optional io_uring prefetch; research-scale NVMe evaluation remains environment-dependent.
 - Adaptive execution planning is implemented, but crossover thresholds still require large benchmark campaigns on public datasets.
-- Native LAGraph/GraphBLAS and GAP wrapper contracts are implemented, but full competitor execution still requires those projects to be built and version-pinned on the target benchmark machine.
+- Native LAGraph/GraphBLAS and GAP builds have executed successfully in hosted CI; publication-grade reruns still require the same immutable systems on the dedicated target machine and official canonical datasets.
 
 ## Not measured / environment-dependent
 
 - True multi-socket NUMA locality/remote-traffic measurements.
 - Large-scale 1/2/4/8/16/32+ thread scaling on dedicated hardware.
-- 100M+ edge research prototype measurements.
+- Repeated controlled-hardware measurements on irregular public 100M+-edge graphs across machines/seeds; current 100M-class results are hosted engineering evidence.
 - Full update-fraction crossover campaign at 0.0001%, 0.001%, 0.01%, 0.1%, 1%, 5% and 10% on public research-scale datasets.
-- Full competitor campaign against NetworkX, igraph, NetworKit, rustworkx, SuiteSparse:GraphBLAS/LAGraph and GAP on equivalent datasets/hardware.
+- Full same-dataset, same-hardware publication campaign across the relevant dynamic and static competitors; hosted NetworKit, GAP and LAGraph evidence does not open this gate.
 - Publication-grade ablation and hardware-counter measurements on dedicated hardware.
 - Research-scale codec throughput/compression-ratio campaign across public graph families.
 - Research-scale NVMe/io_uring throughput and overlap measurements.
@@ -51,8 +55,8 @@ This document maps the repository against the original VeloGraphX implementation
 ## Future / genuinely remaining engineering milestones
 
 - Execute representative public-dataset codec campaigns and feed measured CSV into the calibration tool to select production codec thresholds.
-- Build/version-pin SuiteSparse:GraphBLAS/LAGraph and GAP on the target benchmark environment and execute the normalized competitor campaign.
+- Rebuild the recorded SuiteSparse:GraphBLAS/LAGraph and GAP pins on the dedicated target environment and execute the normalized canonical-dataset campaign.
 - Execute the full update-size crossover, scaling, NUMA, perf-counter and ablation campaigns on dedicated hardware.
-- Research-scale evaluation at 100M+ edges and publication-quality machine-readable result artifacts.
+- Repeat the existing 100M-class engineering campaigns on controlled hardware and public irregular graphs, producing publication-quality machine-readable artifacts.
 
 No unmeasured item is represented as completed, and no benchmark or novelty result is invented.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,3 +1,14 @@
 # Roadmap
 
-The repository now has the broad architectural surfaces requested by the original prompt, but hardware-specific and research-validation work remains intentionally explicit. Next priorities are: calibrated intrinsic SIMD kernels; weighted mutable edges; native NUMA allocation/affinity; ownership-safe NumPy/SciPy/Arrow interoperability; partitioned NVMe backend with asynchronous prefetch; and the full benchmark/ablation campaign across public datasets and competitor baselines.
+VeloGraphX now implements the broad architectural surfaces from the original prompt: weighted mutable graphs, localized exact repair with safe recomputation fallback, runtime-dispatched SIMD paths, NUMA-aware placement and scheduling, NumPy/SciPy/Arrow interoperability, timestamped history, compression codecs, and partitioned mmap/async/`io_uring` storage. Teseo, Boost.Graph and Sortledton exercise the storage-independent graph contract; pinned NetworKit, RisGraph, GAP and LAGraph workflows provide correctness-gated hosted engineering evidence.
+
+The remaining roadmap is therefore validation-led rather than feature-checklist-led:
+
+1. Run the unified canonical publication campaign on dedicated hardware across checksum-pinned web, social/community and road graphs, the full Kronecker/R-MAT series, and the largest clean in-memory boundary.
+2. Establish stable 1/2/4/8/16/32+ thread scaling, genuine multi-socket NUMA behavior and hardware-counter evidence under controlled affinity and frequency settings.
+3. Execute same-hardware competitor campaigns, including RisGraph/NetworKit dynamic BFS and GAP/LAGraph static kernels, without combining incompatible timing contracts.
+4. Complete research-scale update-fraction crossover, selector ablation, compression calibration and repeated 100M+-edge campaigns on public datasets.
+5. Measure the partitioned backend on dedicated NVMe hardware, including bounded-cache behavior and `io_uring` overlap.
+6. Broaden weighted-dynamic evaluation, stabilize the long-term Python API, obtain independent reproduction and turn the retained evidence into a focused systems paper.
+
+Hosted-CI results remain engineering evidence. Publication claims stay gated until the dedicated campaign records immutable datasets, machine/toolchain metadata, raw repetitions, correctness signatures and retained artifacts.


### PR DESCRIPTION
## Summary
- replace the outdated feature-oriented roadmap with the actual validation-led remaining work
- update the competitor research plan for completed Teseo, Sortledton, NetworKit, GAP and LAGraph contracts and immutable pins
- synchronize prompt coverage with hosted 100M-class, native competitor, storage-adapter and multi-root evidence
- correct stale native-competitor documentation while preserving hosted-vs-publication claim boundaries
- update the machine-readable plan contract counts

## Validation
- `git diff --check`
- `python -m json.tool benchmarks/competitor-research-plan.json`
- `python tools/validate_competitor_research_plan.py benchmarks/competitor-research-plan.json`
- asserted 9 competitors / 6 contract-ready / 3 unresolved / publication gate closed
- parsed `.github/workflows/public-dataset-plan.yml` with PyYAML
- compiled the plan validator with `py_compile`
- checked all newly referenced workflows and documents exist
- searched for the superseded stale statements