### PR TITLE
Harden enterprise InfoSec and supply-chain posture

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - security

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,85 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '23 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  repository-guard:
+    name: Secret scan and SBOM
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: High-confidence secret-pattern scan
+        run: python3 tools/security_scan.py
+      - name: Generate SPDX 2.3 source-intake SBOM
+        run: python3 tools/generate_spdx_sbom.py --output build/velographx-sbom.spdx.json
+      - name: Validate SBOM structure
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          p = Path('build/velographx-sbom.spdx.json')
+          doc = json.loads(p.read_text())
+          assert doc['spdxVersion'] == 'SPDX-2.3'
+          assert doc['SPDXID'] == 'SPDXRef-DOCUMENT'
+          assert any(x['name'] == 'VeloGraphX' for x in doc['packages'])
+          print(f"validated {p} with {len(doc['packages'])} packages")
+          PY
+      - name: Upload SPDX SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: velographx-spdx-sbom
+          path: build/velographx-sbom.spdx.json
+          if-no-files-found: error
+          retention-days: 30
+
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      packages: read
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [c-cpp, python]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@6f5948dfacef28e207b48d0905cf90c03365536d # v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+      - name: Build C++ for CodeQL
+        if: matrix.language == 'c-cpp'
+        run: |
+          cmake -S . -B build-codeql \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DVELOGRAPHX_BUILD_TESTS=OFF \
+            -DVELOGRAPHX_BUILD_BENCHMARKS=OFF \
+            -DVELOGRAPHX_BUILD_PYTHON=OFF
+          cmake --build build-codeql --target velographx -j 2
+      - name: Analyze
+        uses: github/codeql-action/analyze@6f5948dfacef28e207b48d0905cf90c03365536d # v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,43 @@
 # Security Policy
 
-Please do not publish exploit details for an unpatched vulnerability in a public issue. Report security concerns privately to the repository owner through GitHub's available private security-reporting channel when enabled. Avoid including secrets, proprietary datasets, credentials or personally identifiable data in reports or test fixtures.
+VeloGraphX treats security, reproducibility, and supply-chain integrity as part of the engineering contract.
+
+## Supported versions
+
+Security fixes are applied to the latest source on `main` and, when practical, to the latest published release. Pre-1.0 APIs may evolve; enterprise consumers should pin a release tag or commit SHA and validate it in their own environment.
+
+## Reporting a vulnerability
+
+Do **not** publish exploit details, credentials, proprietary data, or personally identifiable information in a public issue.
+
+Report suspected vulnerabilities privately through GitHub's private vulnerability reporting/security-advisory mechanism when available. Include only the minimum information needed to reproduce the issue: affected revision, platform/toolchain, impact, reproduction steps, and a minimal non-sensitive proof of concept.
+
+If private reporting is unavailable, contact the repository owner privately and request a secure reporting channel before sending exploit details.
+
+## Coordinated disclosure
+
+Please allow reasonable time to investigate and prepare a fix before public disclosure. Valid reports will be assessed for impact and reproducibility. A security advisory and patched release may be published when appropriate.
+
+## Security boundaries
+
+The core VeloGraphX library is a local C++20 graph-processing library. Its normal core execution path does not require credentials or a remote service. Optional capabilities, benchmark tooling, dataset preparation, Python interoperability, and CI workflows can introduce additional build-time or evaluation-time dependencies and must be reviewed separately by consumers.
+
+VeloGraphX does not claim that cloning the repository automatically satisfies any company's security policy. Enterprise users should run their normal SAST, SCA, secret, malware, license, and binary/provenance controls before deployment.
+
+## Supply-chain controls in this repository
+
+The repository maintains:
+
+- build and correctness CI;
+- ASan/UBSan testing;
+- checksum validation for prepared dataset fixtures;
+- CodeQL static analysis;
+- repository secret-pattern scanning;
+- an SPDX SBOM generation step for source-intake review;
+- Dependabot updates for GitHub Actions dependencies.
+
+See `docs/enterprise-security.md` for the enterprise intake model, dependency boundaries, SBOM scope, and runtime-impact statement.
+
+## Sensitive data
+
+Never commit or attach secrets, access tokens, private keys, credentials, proprietary datasets, production payment/customer data, or personally identifiable information to issues, tests, fixtures, benchmarks, examples, or vulnerability reports.

--- a/docs/enterprise-security.md
+++ b/docs/enterprise-security.md
@@ -1,0 +1,83 @@
+# Enterprise security and supply-chain posture
+
+This document is intended to help security, open-source governance, and engineering teams evaluate VeloGraphX before internal use.
+
+## Runtime boundary
+
+VeloGraphX core is a local C++20 graph-processing library. The core build does not require a remote service, credentials, or telemetry. The optional `VELOGRAPHX_ENABLE_IO_URING` path adds a Linux `liburing` dependency. Python bindings are disabled by default and, when enabled, use pybind11 at build time plus NumPy/SciPy/PyArrow interoperability in tests/examples.
+
+Benchmark and dataset tooling is separate from the core runtime and may intentionally access local files or externally supplied datasets. Consumers should review those tools according to their own data-governance policy.
+
+## Security controls
+
+The repository uses layered controls rather than treating one scanner as a certification:
+
+- normal Linux/macOS build and test CI;
+- ASan/UBSan sanitizer CI;
+- SHA-256 validation for prepared dataset fixtures;
+- CodeQL static analysis for C/C++ and Python source;
+- repository secret-pattern scanning for high-confidence credential/key signatures;
+- automated SPDX JSON SBOM generation for source-intake review;
+- Dependabot for GitHub Actions dependency updates.
+
+These controls reduce avoidable risk but do not replace a consuming company's SAST, SCA, malware, license, provenance, container, or policy-specific checks.
+
+## Dependency model
+
+### Core C++ library
+
+Mandatory third-party runtime dependencies: **none declared by the default CMake build**.
+
+Optional dependency:
+
+- `liburing` when `VELOGRAPHX_ENABLE_IO_URING=ON` on Linux.
+
+### Optional Python interoperability
+
+Python bindings are opt-in (`VELOGRAPHX_BUILD_PYTHON=ON`). CI interoperability uses:
+
+- pybind11
+- NumPy
+- SciPy
+- PyArrow
+
+The source-intake SBOM records these components and resolves installed versions when available in the generation environment.
+
+## SBOM
+
+`tools/generate_spdx_sbom.py` emits an SPDX 2.3 JSON document. It is deliberately conservative: it records VeloGraphX, the optional `liburing` component, and optional Python interoperability packages. When Python package versions are installed, exact versions are captured; otherwise the version is reported as `NOASSERTION`.
+
+For production intake, consumers should also generate an environment-specific SBOM after dependency resolution and package installation, because transitive dependencies depend on the platform and chosen optional features.
+
+## Source provenance and pinning
+
+For reproducible internal use:
+
+1. Pin VeloGraphX to a release tag or immutable commit SHA.
+2. Retain the commit SHA in internal build metadata.
+3. Generate and archive an SBOM in the target build environment.
+4. Verify all externally obtained datasets/artifacts with organization-approved checksums or signatures.
+5. Re-run the organization's normal security and license scanners on the pinned revision.
+
+GitHub Actions used by the dedicated security workflow are pinned to immutable commit SHAs where practical. Dependabot is configured to surface upstream action updates for review.
+
+## Data handling
+
+No production credentials, payment/customer data, proprietary datasets, or PII should be committed to this repository or included in tests, issues, examples, benchmark artifacts, or security reports.
+
+## Performance impact
+
+The enterprise hardening controls are CI/source-governance controls. They do **not** change graph algorithms, benchmark implementations, release compiler flags, or runtime execution paths. CodeQL, secret scanning, and SBOM generation only add CI time. Sanitizers remain confined to the dedicated debug/sanitizer build and are not enabled in normal Release builds.
+
+## Enterprise intake checklist
+
+A consuming company can use this minimal intake sequence:
+
+1. Clone/pin an immutable revision.
+2. Run secret, malware, license, SAST, and SCA scanners required by company policy.
+3. Review `LICENSE`, `SECURITY.md`, this document, and the generated SPDX SBOM.
+4. Build with optional features disabled unless required.
+5. Run `ctest` and the sanitizer configuration in a controlled build environment.
+6. Record accepted dependencies, compiler/toolchain, and revision in internal governance systems.
+
+Passing these repository controls does not guarantee approval by every InfoSec organization; final approval depends on the consuming company's policies and deployment context.

--- a/tools/generate_spdx_sbom.py
+++ b/tools/generate_spdx_sbom.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Generate a conservative SPDX 2.3 JSON SBOM for VeloGraphX source intake."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from datetime import datetime, timezone
+from importlib import metadata
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROJECT_VERSION = "0.8.0"
+
+OPTIONAL_PYTHON = ["pybind11", "numpy", "scipy", "pyarrow"]
+
+
+def git_revision() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+        ).strip()
+    except Exception:
+        return "NOASSERTION"
+
+
+def installed_version(name: str) -> str:
+    try:
+        return metadata.version(name)
+    except metadata.PackageNotFoundError:
+        return "NOASSERTION"
+
+
+def package(spdx_id: str, name: str, version: str, *, comment: str, purl_name: str | None = None) -> dict:
+    item = {
+        "SPDXID": spdx_id,
+        "name": name,
+        "versionInfo": version,
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": False,
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "comment": comment,
+    }
+    if purl_name and version != "NOASSERTION":
+        item["externalRefs"] = [{
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": f"pkg:pypi/{purl_name}@{version}",
+        }]
+    return item
+
+
+def build_document() -> dict:
+    revision = git_revision()
+    namespace_rev = revision if revision != "NOASSERTION" else "unknown"
+    packages = [
+        {
+            "SPDXID": "SPDXRef-Package-VeloGraphX",
+            "name": "VeloGraphX",
+            "versionInfo": PROJECT_VERSION,
+            "downloadLocation": "https://github.com/sauravsingla/VeloGraphX",
+            "filesAnalyzed": False,
+            "licenseConcluded": "Apache-2.0",
+            "licenseDeclared": "Apache-2.0",
+            "copyrightText": "NOASSERTION",
+            "comment": f"Source revision: {revision}. Core default CMake build declares no mandatory third-party runtime dependency.",
+        },
+        package(
+            "SPDXRef-Package-liburing",
+            "liburing",
+            "NOASSERTION",
+            comment="Optional Linux dependency used only when VELOGRAPHX_ENABLE_IO_URING=ON.",
+        ),
+    ]
+
+    relationships = [{
+        "spdxElementId": "SPDXRef-DOCUMENT",
+        "relationshipType": "DESCRIBES",
+        "relatedSpdxElement": "SPDXRef-Package-VeloGraphX",
+    }, {
+        "spdxElementId": "SPDXRef-Package-VeloGraphX",
+        "relationshipType": "OPTIONAL_DEPENDENCY_OF",
+        "relatedSpdxElement": "SPDXRef-Package-liburing",
+        "comment": "liburing is optional and disabled by default.",
+    }]
+
+    for name in OPTIONAL_PYTHON:
+        spdx_id = f"SPDXRef-Package-python-{name.lower()}"
+        version = installed_version(name)
+        packages.append(package(
+            spdx_id,
+            name,
+            version,
+            comment="Optional Python build/interoperability dependency; Python bindings are disabled by default.",
+            purl_name=name,
+        ))
+        relationships.append({
+            "spdxElementId": spdx_id,
+            "relationshipType": "OPTIONAL_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Package-VeloGraphX",
+        })
+
+    return {
+        "spdxVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "VeloGraphX-source-intake-sbom",
+        "documentNamespace": f"https://github.com/sauravsingla/VeloGraphX/sbom/{namespace_rev}",
+        "creationInfo": {
+            "created": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "creators": ["Tool: VeloGraphX tools/generate_spdx_sbom.py"],
+        },
+        "packages": packages,
+        "relationships": relationships,
+        "documentComment": "Source-intake SBOM. Generate an environment-specific SBOM after resolving platform-specific and optional dependencies for production use.",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", default="build/velographx-sbom.spdx.json")
+    args = parser.parse_args()
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(build_document(), indent=2) + "\n", encoding="utf-8")
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/generate_spdx_sbom.py
+++ b/tools/generate_spdx_sbom.py
@@ -81,9 +81,9 @@ def build_document() -> dict:
         "relationshipType": "DESCRIBES",
         "relatedSpdxElement": "SPDXRef-Package-VeloGraphX",
     }, {
-        "spdxElementId": "SPDXRef-Package-VeloGraphX",
+        "spdxElementId": "SPDXRef-Package-liburing",
         "relationshipType": "OPTIONAL_DEPENDENCY_OF",
-        "relatedSpdxElement": "SPDXRef-Package-liburing",
+        "relatedSpdxElement": "SPDXRef-Package-VeloGraphX",
         "comment": "liburing is optional and disabled by default.",
     }]
 

--- a/tools/security_scan.py
+++ b/tools/security_scan.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Fail CI on high-confidence secret/key signatures in tracked text files.
+
+This is a lightweight repository guard, not a replacement for enterprise secret scanning.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MAX_FILE_BYTES = 2_000_000
+
+PATTERNS = {
+    "private-key": re.compile(rb"-----BEGIN (?:RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----"),
+    "aws-access-key": re.compile(rb"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"),
+    "github-token": re.compile(rb"\bgh[pousr]_[A-Za-z0-9_]{30,255}\b"),
+    "github-fine-grained-token": re.compile(rb"\bgithub_pat_[A-Za-z0-9_]{20,255}\b"),
+    "slack-token": re.compile(rb"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
+}
+
+ALLOWLIST_PATHS = {
+    "tools/security_scan.py",
+}
+
+
+def tracked_files() -> list[str]:
+    output = subprocess.check_output(["git", "ls-files", "-z"], cwd=ROOT)
+    return [item.decode("utf-8") for item in output.split(b"\0") if item]
+
+
+def main() -> int:
+    findings: list[tuple[str, str]] = []
+    for rel in tracked_files():
+        if rel in ALLOWLIST_PATHS:
+            continue
+        path = ROOT / rel
+        if not path.is_file() or path.stat().st_size > MAX_FILE_BYTES:
+            continue
+        try:
+            data = path.read_bytes()
+        except OSError:
+            continue
+        if b"\0" in data:
+            continue
+        for name, pattern in PATTERNS.items():
+            if pattern.search(data):
+                findings.append((rel, name))
+
+    if findings:
+        print("Potential high-confidence secrets detected:")
+        for rel, name in findings:
+            print(f"  - {rel}: {name}")
+        print("Remove the secret from git history as appropriate and rotate it before continuing.")
+        return 1
+
+    print(f"Security scan passed: {len(tracked_files())} tracked files checked for high-confidence secret signatures.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds enterprise-oriented repository hardening without changing graph algorithms, benchmark implementations, release compiler flags, or runtime execution paths.

### Included
- expanded vulnerability disclosure and security boundaries in `SECURITY.md`
- enterprise security/supply-chain intake documentation
- pinned dedicated Security workflow with CodeQL for C/C++ and Python
- high-confidence repository secret-pattern scan
- SPDX 2.3 source-intake SBOM generation and CI artifact
- Dependabot updates for GitHub Actions
- explicit runtime-impact and optional-dependency documentation

### Runtime impact
None expected. These changes are CI/documentation/tooling only. Sanitizers remain in debug CI; the normal Release build and graph engine are unchanged.

### Validation
The PR is intended to run the existing CI plus the new Security workflow. The new security workflow uses immutable action commit SHAs and least-privilege permissions.