### PR TITLE
Make VeloGraphX pip-installable

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,106 @@
+name: Publish Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  validate-release:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Check tag matches package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          version = tomllib.loads(Path('pyproject.toml').read_text())['project']['version']
+          expected = f'v{version}'
+          actual = os.environ['RELEASE_TAG']
+          if actual != expected:
+              raise SystemExit(f'Release tag {actual!r} does not match package version {expected!r}')
+          print(f'Release tag validated: {actual}')
+          PY
+
+  wheels:
+    name: Build wheels (${{ matrix.os }})
+    needs: validate-release
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-15-intel
+          - macos-14
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Build and test wheels
+        uses: pypa/cibuildwheel@v4.2.0
+      - name: Upload wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: pypi-wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+          if-no-files-found: error
+
+  sdist:
+    name: Build source distribution
+    needs: validate-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Build source distribution
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --sdist
+      - name: Upload source distribution
+        uses: actions/upload-artifact@v6
+        with:
+          name: pypi-sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: [wheels, sdist]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/velographx/
+    permissions:
+      id-token: write
+    steps:
+      - name: Download release distributions
+        uses: actions/download-artifact@v5
+        with:
+          pattern: pypi-*
+          path: dist
+          merge-multiple: true
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,53 +5,79 @@ on:
     paths:
       - 'pyproject.toml'
       - 'CMakeLists.txt'
+      - 'cmake/**'
       - 'python/**'
       - 'include/**'
+      - 'src/**'
+      - 'README.md'
+      - 'LICENSE'
       - '.github/workflows/python-package.yml'
   pull_request:
     paths:
       - 'pyproject.toml'
       - 'CMakeLists.txt'
+      - 'cmake/**'
       - 'python/**'
       - 'include/**'
+      - 'src/**'
+      - 'README.md'
+      - 'LICENSE'
       - '.github/workflows/python-package.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  wheel-smoke:
+  wheels:
+    name: Wheels (${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-15-intel
+          - macos-14
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Build and test wheels
+        uses: pypa/cibuildwheel@v4.2.0
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+          if-no-files-found: error
+
+  sdist:
+    name: Source distribution
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - name: Build wheel
+      - name: Build source distribution
         run: |
           python -m pip install --upgrade pip build
-          python -m build --wheel
-      - name: Install wheel
-        run: python -m pip install dist/*.whl
-      - name: Import and dynamic-graph smoke test
+          python -m build --sdist
+      - name: Install and smoke-test source distribution
         run: |
-          python - <<'PY'
-          import velographx as vx
-
-          graph = vx.Graph(4, False)
-          initial = vx.UpdateBatch()
-          initial.add(0, 1)
-          initial.add(1, 2)
-          graph.apply(initial)
-
-          bfs = vx.IncrementalBFS(graph, 0)
-          assert bfs.distances[:3] == [0, 1, 2]
-
-          update = vx.UpdateBatch()
-          update.add(2, 3)
-          bfs.apply(update)
-          assert bfs.distances == [0, 1, 2, 3]
-
-          print('VeloGraphX wheel install OK')
-          PY
+          python -m pip install dist/*.tar.gz
+          python -c "import velographx as vx; g=vx.Graph(4, False); u=vx.UpdateBatch(); u.add(0, 1); u.add(1, 2); g.apply(u); bfs=vx.IncrementalBFS(g, 0); assert bfs.distances[:3] == [0, 1, 2]"
+      - name: Upload source distribution
+        uses: actions/upload-artifact@v6
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,57 @@
+name: Python Package
+
+on:
+  push:
+    paths:
+      - 'pyproject.toml'
+      - 'CMakeLists.txt'
+      - 'python/**'
+      - 'include/**'
+      - '.github/workflows/python-package.yml'
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+      - 'CMakeLists.txt'
+      - 'python/**'
+      - 'include/**'
+      - '.github/workflows/python-package.yml'
+
+jobs:
+  wheel-smoke:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel
+      - name: Install wheel
+        run: python -m pip install dist/*.whl
+      - name: Import and dynamic-graph smoke test
+        run: |
+          python - <<'PY'
+          import velographx as vx
+
+          graph = vx.Graph(4, False)
+          initial = vx.UpdateBatch()
+          initial.add(0, 1)
+          initial.add(1, 2)
+          graph.apply(initial)
+
+          bfs = vx.IncrementalBFS(graph, 0)
+          assert bfs.distances[:3] == [0, 1, 2]
+
+          update = vx.UpdateBatch()
+          update.add(2, 3)
+          bfs.apply(update)
+          assert bfs.distances == [0, 1, 2, 3]
+
+          print('VeloGraphX wheel install OK')
+          PY

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,6 +12,7 @@ on:
       - 'README.md'
       - 'LICENSE'
       - '.github/workflows/python-package.yml'
+      - '.github/workflows/publish-pypi.yml'
   pull_request:
     paths:
       - 'pyproject.toml'
@@ -23,6 +24,7 @@ on:
       - 'README.md'
       - 'LICENSE'
       - '.github/workflows/python-package.yml'
+      - '.github/workflows/publish-pypi.yml'
   workflow_dispatch:
 
 permissions:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(VeloGraphX VERSION 0.8.0 LANGUAGES CXX)
+project(VeloGraphX VERSION 0.8.2 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = [
+  "scikit-build-core>=0.10",
+  "pybind11>=2.12",
+]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "velographx"
+version = "0.8.1"
+description = "Exact incremental graph analytics for evolving graphs, powered by a C++20 engine."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { file = "LICENSE" }
+authors = [
+  { name = "Saurav Singla" },
+]
+keywords = [
+  "dynamic-graphs",
+  "graph-analytics",
+  "incremental-computing",
+  "high-performance-computing",
+  "cpp20",
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: C++",
+  "Programming Language :: C++ :: 20",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Topic :: Scientific/Engineering :: Information Analysis",
+  "Topic :: Software Development :: Libraries",
+]
+
+[project.urls]
+Homepage = "https://github.com/sauravsingla/VeloGraphX"
+Repository = "https://github.com/sauravsingla/VeloGraphX"
+Documentation = "https://github.com/sauravsingla/VeloGraphX#readme"
+Issues = "https://github.com/sauravsingla/VeloGraphX/issues"
+
+[tool.scikit-build]
+minimum-version = "0.10"
+wheel.packages = []
+install.components = ["python"]
+cmake.build-type = "Release"
+
+[tool.scikit-build.cmake.define]
+VELOGRAPHX_BUILD_PYTHON = "ON"
+VELOGRAPHX_BUILD_TESTS = "OFF"
+VELOGRAPHX_BUILD_BENCHMARKS = "OFF"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "velographx"
-version = "0.8.1"
+version = "0.8.2"
 description = "Exact incremental graph analytics for evolving graphs, powered by a C++20 engine."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -31,6 +31,12 @@ classifiers = [
   "Programming Language :: C++ :: 20",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering :: Information Analysis",
   "Topic :: Software Development :: Libraries",
 ]
@@ -51,3 +57,12 @@ cmake.build-type = "Release"
 VELOGRAPHX_BUILD_PYTHON = "ON"
 VELOGRAPHX_BUILD_TESTS = "OFF"
 VELOGRAPHX_BUILD_BENCHMARKS = "OFF"
+VELOGRAPHX_BUILD_EXAMPLES = "OFF"
+
+[tool.cibuildwheel]
+build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
+skip = ["*-musllinux_*"]
+test-command = "python -c \"import velographx as vx; g=vx.Graph(4, False); u=vx.UpdateBatch(); u.add(0, 1); u.add(1, 2); g.apply(u); bfs=vx.IncrementalBFS(g, 0); assert bfs.distances[:3] == [0, 1, 2]\""
+
+[tool.cibuildwheel.macos]
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ Issues = "https://github.com/sauravsingla/VeloGraphX/issues"
 [tool.scikit-build]
 minimum-version = "0.10"
 wheel.packages = []
+build.targets = ["velographx_python"]
 install.components = ["python"]
 cmake.build-type = "Release"
 
@@ -57,7 +58,6 @@ cmake.build-type = "Release"
 VELOGRAPHX_BUILD_PYTHON = "ON"
 VELOGRAPHX_BUILD_TESTS = "OFF"
 VELOGRAPHX_BUILD_BENCHMARKS = "OFF"
-VELOGRAPHX_BUILD_EXAMPLES = "OFF"
 
 [tool.cibuildwheel]
 build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,6 @@
 if(SKBUILD)
+  set(PYBIND11_FINDPYTHON ON)
+  find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
   find_package(pybind11 CONFIG REQUIRED)
 else()
   find_package(pybind11 CONFIG QUIET)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -11,9 +11,8 @@ if(pybind11_FOUND)
 
   if(SKBUILD)
     install(TARGETS velographx_python
-      LIBRARY DESTINATION .
-      RUNTIME DESTINATION .
-      COMPONENT python
+      LIBRARY DESTINATION . COMPONENT python
+      RUNTIME DESTINATION . COMPONENT python
     )
   endif()
 else()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,8 +1,21 @@
-find_package(pybind11 CONFIG QUIET)
+if(SKBUILD)
+  find_package(pybind11 CONFIG REQUIRED)
+else()
+  find_package(pybind11 CONFIG QUIET)
+endif()
+
 if(pybind11_FOUND)
   pybind11_add_module(velographx_python bindings.cpp)
   target_include_directories(velographx_python PRIVATE ${PROJECT_SOURCE_DIR}/include)
   set_target_properties(velographx_python PROPERTIES OUTPUT_NAME velographx)
+
+  if(SKBUILD)
+    install(TARGETS velographx_python
+      LIBRARY DESTINATION .
+      RUNTIME DESTINATION .
+      COMPONENT python
+    )
+  endif()
 else()
   message(STATUS "pybind11 not found; Python extension skipped")
 endif()

--- a/python/README.md
+++ b/python/README.md
@@ -2,11 +2,34 @@
 
 VeloGraphX provides optional pybind11 bindings while keeping the native C++ engine on the performance-critical paths.
 
-## Build
+## Install with pip from a checkout
 
-Install pybind11, then configure with the Python bindings enabled:
+The repository is now packaged with `pyproject.toml` and scikit-build-core, so a local checkout can be built and installed with one command:
 
 ```bash
+python -m pip install .
+```
+
+For an editable developer install:
+
+```bash
+python -m pip install -e .
+```
+
+The build backend installs pybind11 in an isolated build environment and configures the CMake Python target automatically. A C++20-capable compiler is still required when building from source.
+
+Once VeloGraphX wheels are published to PyPI, end users will be able to install the published package with:
+
+```bash
+python -m pip install velographx
+```
+
+## Manual CMake build
+
+For development or direct CMake use, the previous build path remains supported:
+
+```bash
+python -m pip install pybind11
 cmake -S . -B build-python -DCMAKE_BUILD_TYPE=Release \
   -DVELOGRAPHX_BUILD_TESTS=OFF \
   -DVELOGRAPHX_BUILD_BENCHMARKS=OFF \
@@ -14,8 +37,6 @@ cmake -S . -B build-python -DCMAKE_BUILD_TYPE=Release \
   -Dpybind11_DIR="$(python -m pybind11 --cmakedir)"
 cmake --build build-python -j
 ```
-
-The resulting `velographx` extension is built from the same C++ engine used by the native API.
 
 ## Interoperability
 
@@ -25,7 +46,7 @@ The bindings include tested interoperability paths for:
 - SciPy CSR matrices via `from_scipy_csr`;
 - Apache Arrow tables via `from_arrow_table`.
 
-CI exercises these adapters alongside dynamic graph operations, incremental BFS, connected components, k-core, PageRank and weighted SSSP bindings.
+CI exercises these adapters alongside dynamic graph operations, incremental BFS, connected components, k-core, PageRank and weighted SSSP bindings. A separate package workflow builds an installable wheel on Linux and macOS and imports the installed module as a smoke test.
 
 Ownership, lifetime and dtype behavior are treated as correctness contracts and are validated in CI rather than being described as unverified zero-copy guarantees.
 

--- a/python/README.md
+++ b/python/README.md
@@ -46,7 +46,7 @@ The bindings include tested interoperability paths for:
 - SciPy CSR matrices via `from_scipy_csr`;
 - Apache Arrow tables via `from_arrow_table`.
 
-CI exercises these adapters alongside dynamic graph operations, incremental BFS, connected components, k-core, PageRank and weighted SSSP bindings. A separate package workflow builds an installable wheel on Linux and macOS and imports the installed module as a smoke test.
+CI exercises these adapters alongside dynamic graph operations, incremental BFS, connected components, k-core, PageRank and weighted SSSP bindings. The package workflow builds and smoke-tests CPython 3.9–3.14 wheels for manylinux x86_64, Windows x64, macOS Intel and macOS Apple Silicon, plus a source distribution.
 
 Ownership, lifetime and dtype behavior are treated as correctness contracts and are validated in CI rather than being described as unverified zero-copy guarantees.
 


### PR DESCRIPTION
## Summary

Adds production-oriented Python packaging around the existing pybind11 bindings so VeloGraphX can be installed through pip, built into portable release wheels, and published securely through PyPI Trusted Publishing.

### Changes
- add `pyproject.toml` using scikit-build-core + pybind11
- align Python and CMake package version to `0.8.2`
- support CPython 3.9 through 3.14
- build only the `velographx_python` target during Python packaging
- install the compiled `velographx` extension into the wheel
- use modern CMake FindPython discovery for pybind11 builds
- use cibuildwheel for portable manylinux, Windows x64, macOS Intel, and macOS Apple Silicon wheels
- set a macOS 11 deployment target instead of inheriting the hosted runner's current macOS version
- build and smoke-test a source distribution separately
- run an installed-wheel dynamic BFS smoke test for every generated wheel
- upload wheels/source distributions as CI artifacts
- add a release-only PyPI Trusted Publishing workflow with a release-tag/version guard
- document `python -m pip install .` and editable installs

### User experience
From a checkout:

```bash
python -m pip install .
```

After v0.8.2 is published to PyPI, the end-user command becomes:

```bash
python -m pip install velographx
```

### Release safety
Merging this PR cannot publish to PyPI. Publication only runs when a GitHub Release is explicitly published, requires the release tag to match `v<project.version>`, and uses the protected `pypi` GitHub environment plus PyPI OIDC Trusted Publishing. PyPI must trust `.github/workflows/publish-pypi.yml` for `sauravsingla/VeloGraphX` before the publish job can succeed.
