### PR TITLE
Validate one-sided warm-up policy for adaptive BFS (#61)

### DIFF
--- a/.github/workflows/issue61-warmup-validation.yml
+++ b/.github/workflows/issue61-warmup-validation.yml
@@ -6,7 +6,6 @@ on:
       - 'fix/issue-61-one-sided-warmup'
     paths:
       - '.github/workflows/issue61-warmup-validation.yml'
-      - 'tools/issue61_one_sided_warmup.py'
       - 'benchmarks/adaptive_policy_bfs.cpp'
   workflow_dispatch:
 
@@ -19,6 +18,8 @@ jobs:
       OMP_PROC_BIND: 'true'
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -30,9 +31,9 @@ jobs:
         run: |
           cmake -S . -B build/vx -G Ninja -DCMAKE_BUILD_TYPE=Release -DVELOGRAPHX_BUILD_TESTS=OFF -DVELOGRAPHX_BUILD_BENCHMARKS=ON
           cmake --build build/vx --target velographx_external_risgraph_bfs -j 2
-          c++ -O3 -DNDEBUG -std=c++20 -Iinclude benchmarks/adaptive_policy_bfs.cpp build/vx/libvelographx.a -pthread -o build/adaptive_policy_bfs_baseline
-          python tools/issue61_one_sided_warmup.py --input benchmarks/adaptive_policy_bfs.cpp --output build/adaptive_policy_bfs_issue61.cpp
-          c++ -O3 -DNDEBUG -std=c++20 -Iinclude build/adaptive_policy_bfs_issue61.cpp build/vx/libvelographx.a -pthread -o build/adaptive_policy_bfs_candidate
+          git show origin/main:benchmarks/adaptive_policy_bfs.cpp > build/adaptive_policy_bfs_baseline.cpp
+          c++ -O3 -DNDEBUG -std=c++20 -Iinclude build/adaptive_policy_bfs_baseline.cpp build/vx/libvelographx.a -pthread -o build/adaptive_policy_bfs_baseline
+          c++ -O3 -DNDEBUG -std=c++20 -Iinclude benchmarks/adaptive_policy_bfs.cpp build/vx/libvelographx.a -pthread -o build/adaptive_policy_bfs_candidate
       - name: Prepare pinned datasets
         run: |
           mkdir -p build/issue61/datasets build/issue61/runs

--- a/.github/workflows/issue61-warmup-validation.yml
+++ b/.github/workflows/issue61-warmup-validation.yml
@@ -1,0 +1,127 @@
+name: Issue 61 One-sided Warm-up Validation
+
+on:
+  push:
+    branches:
+      - 'fix/issue-61-one-sided-warmup'
+    paths:
+      - '.github/workflows/issue61-warmup-validation.yml'
+      - 'tools/issue61_one_sided_warmup.py'
+      - 'benchmarks/adaptive_policy_bfs.cpp'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    env:
+      OMP_NUM_THREADS: '1'
+      OMP_PROC_BIND: 'true'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ninja-build
+      - name: Build baseline and candidate harnesses
+        run: |
+          cmake -S . -B build/vx -G Ninja -DCMAKE_BUILD_TYPE=Release -DVELOGRAPHX_BUILD_TESTS=OFF -DVELOGRAPHX_BUILD_BENCHMARKS=ON
+          cmake --build build/vx --target velographx_external_risgraph_bfs -j 2
+          c++ -O3 -DNDEBUG -std=c++20 -Iinclude benchmarks/adaptive_policy_bfs.cpp build/vx/libvelographx.a -pthread -o build/adaptive_policy_bfs_baseline
+          python tools/issue61_one_sided_warmup.py --input benchmarks/adaptive_policy_bfs.cpp --output build/adaptive_policy_bfs_issue61.cpp
+          c++ -O3 -DNDEBUG -std=c++20 -Iinclude build/adaptive_policy_bfs_issue61.cpp build/vx/libvelographx.a -pthread -o build/adaptive_policy_bfs_candidate
+      - name: Prepare pinned datasets
+        run: |
+          mkdir -p build/issue61/datasets build/issue61/runs
+          python tools/prepare_dataset.py --manifest datasets/manifest.public-small.json --output-dir build/issue61/datasets --dataset web-Google
+          python tools/prepare_dataset.py --manifest datasets/manifest.public-small.json --output-dir build/issue61/datasets --dataset ca-GrQc
+          python tools/prepare_dataset.py --manifest datasets/manifest.public-small.json --output-dir build/issue61/datasets --dataset soc-Epinions1
+          python tools/prepare_pinned_edge_stream.py --input build/issue61/datasets/web-Google.txt --output build/issue61/web-Google.txt --report build/issue61/web-normalization.json --expected-sha256 8c0f453f1eb1e24ad145e36e542b129083237e96e585abae768927bdb70167d1 --expected-vertices 875713 --expected-edges 5105039
+          python tools/prepare_symmetric_pinned_edge_stream.py --input build/issue61/datasets/ca-GrQc.txt --output build/issue61/ca-GrQc.txt --report build/issue61/ca-normalization.json --expected-sha256 513efa8bb5c6d3d739797ca028d4a26a7df6bc20adcf3e722e18d1bcdb0e62d5 --expected-vertices 5242 --expected-source-rows 28980 --expected-self-loops 12 --expected-nonloop-pair-multiplicity 2 --expected-unique-nonloop-pairs 14484
+          gzip -dc build/issue61/datasets/soc-Epinions1.gz > build/issue61/epinions-source.txt
+          python tools/prepare_pinned_edge_stream.py --input build/issue61/epinions-source.txt --output build/issue61/soc-Epinions1.txt --report build/issue61/epinions-normalization.json --expected-sha256 3e42b000e66cada74053ac7f8b24de291f9837264421dc2f3730b45cc58d17b1 --expected-vertices 75879 --expected-edges 508837
+      - name: Reproduce Issue 61 exactly and compare candidate
+        run: |
+          python - <<'PY'
+          import json, subprocess
+          from pathlib import Path
+          for variant in ('baseline','candidate'):
+              exe=f'build/adaptive_policy_bfs_{variant}'
+              for rep in range(1,4):
+                  out=Path(f'build/issue61/runs/issue61__{variant}__{rep}.json')
+                  with out.open('w') as f:
+                      subprocess.run([exe,'build/issue61/web-Google.txt','771121','0.99','32768','0.05'],stdout=f,check=True)
+                  d=json.load(out.open())
+                  assert d['all_policies_exact']
+          PY
+      - name: Run before-after multiroot multidataset campaign
+        run: |
+          python - <<'PY'
+          import json, subprocess
+          from pathlib import Path
+          configs=[
+            ('ca-GrQc',0.75,[4282,2465,1974],[96,384,1536]),
+            ('soc-Epinions1',0.90,[763,634,71391],[384,1536,6144]),
+            ('web-Google',0.99,[481807,771121,391806],[1536,6144,24576]),
+          ]
+          for variant in ('baseline','candidate'):
+            exe=f'build/adaptive_policy_bfs_{variant}'
+            for dataset,rate,roots,batches in configs:
+              for root in roots:
+                for batch in batches:
+                  for rep in range(1,4):
+                    out=Path(f'build/issue61/runs/campaign__{variant}__{dataset}__r{root}__b{batch}__{rep}.json')
+                    with out.open('w') as f:
+                      subprocess.run([exe,f'build/issue61/{dataset}.txt',str(root),str(rate),str(batch),'0.01'],stdout=f,check=True)
+                    d=json.load(out.open())
+                    assert d['all_policies_exact']
+          PY
+      - name: Produce before-after report and regression gate
+        run: |
+          python - <<'PY'
+          import json, statistics
+          from pathlib import Path
+          root=Path('build/issue61/runs')
+          def adaptive(d): return next(p for p in d['policies'] if p['name']=='adaptive')
+          issue={}
+          for variant in ('baseline','candidate'):
+            rows=[]
+            for p in sorted(root.glob(f'issue61__{variant}__*.json')):
+              d=json.load(p.open()); a=adaptive(d); full=next(x for x in d['policies'] if x['name']=='always_full')
+              rows.append({'adaptive_us':a['total_us'],'full_us':full['total_us'],'trace':a.get('trace',[])})
+            issue[variant]={
+              'adaptive_median_us':statistics.median(r['adaptive_us'] for r in rows),
+              'full_median_us':statistics.median(r['full_us'] for r in rows),
+              'adaptive_over_full':statistics.median(r['adaptive_us']/r['full_us'] for r in rows),
+              'second_batch_reasons':[r['trace'][1]['reason'] if len(r['trace'])>1 else None for r in rows],
+            }
+          campaign={}
+          for variant in ('baseline','candidate'):
+            ratios=[]; exact=True
+            for p in root.glob(f'campaign__{variant}__*.json'):
+              d=json.load(p.open()); exact &= d['all_policies_exact']; a=adaptive(d)
+              best=min(x['total_us'] for x in d['policies'])
+              ratios.append(a['total_us']/best)
+            campaign[variant]={
+              'runs':len(ratios),'all_exact':exact,
+              'mean_adaptive_to_run_best':sum(ratios)/len(ratios),
+              'median_adaptive_to_run_best':statistics.median(ratios),
+              'worst_adaptive_to_run_best':max(ratios),
+            }
+          report={'issue61':issue,'campaign':campaign}
+          Path('build/issue61/report.json').write_text(json.dumps(report,indent=2))
+          print(json.dumps(report,indent=2))
+          assert issue['candidate']['adaptive_over_full'] <= issue['baseline']['adaptive_over_full'], 'Issue #61 candidate did not improve target case'
+          assert campaign['candidate']['all_exact']
+          # Shared runners are noisy: allow <=5% mean relative degradation before rejecting.
+          assert campaign['candidate']['mean_adaptive_to_run_best'] <= campaign['baseline']['mean_adaptive_to_run_best'] * 1.05, 'candidate regressed campaign mean >5%'
+          PY
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: issue61-one-sided-warmup-validation
+          path: build/issue61/
+          retention-days: 90

--- a/benchmarks/adaptive_policy_bfs.cpp
+++ b/benchmarks/adaptive_policy_bfs.cpp
@@ -194,6 +194,7 @@ PolicyResult run_policy(const std::string& policy,
   std::size_t incremental_age = kFreshAge + 1;
   std::size_t full_age = large_scale ? 0 : kFreshAge + 1;
   bool first_batch = true;
+  bool one_sided_full_warmup_used = false;
 
   for (std::size_t begin = imported_edges; begin < edges.size(); begin += batch_size) {
     const auto end = std::min(begin + batch_size, edges.size());
@@ -246,9 +247,15 @@ PolicyResult run_policy(const std::string& policy,
         } else if (shallow_cold_start) {
           choose_full = true;
           trace.reason = "large_shallow_cold_start";
+        } else if (!have_incremental && have_full && !one_sided_full_warmup_used) {
+          // Full cost is measured while incremental cost is unknown. Keep the measured
+          // baseline for one warm-up decision, then allow an incremental calibration probe.
+          choose_full = true;
+          one_sided_full_warmup_used = true;
+          trace.reason = "large_one_sided_full";
         } else if (!have_incremental) {
           choose_full = update_fraction >= simple_update_fraction;
-          trace.reason = choose_full ? "large_warmup_full" : "large_warmup_incremental";
+          trace.reason = choose_full ? "large_warmup_full" : "large_one_sided_probe_incremental";
         } else if (inc_lower > full_upper) {
           choose_full = true;
           trace.reason = "large_uncertainty_confident_full";
@@ -416,7 +423,7 @@ int main(int argc, char** argv) {
   }
 
   bool all_exact = true;
-  std::cout << "{\"schema_version\":6,\"selector\":\"scale-conditioned-selector-owned-v3\""
+  std::cout << "{\"schema_version\":7,\"selector\":\"bounded-one-sided-warmup-v5\""
             << ",\"root\":" << root64
             << ",\"vertices\":" << vertices
             << ",\"batch_size\":" << batch_size

--- a/tools/issue61_one_sided_warmup.py
+++ b/tools/issue61_one_sided_warmup.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Apply the Issue #61 one-sided warm-up selector candidate.
+
+The candidate keeps exploration for very small update batches, but when a large-graph
+selector has a measured full-recompute cost and no incremental observation yet, it
+uses a stricter bounded-probe threshold (25% of the configured simple threshold)
+instead of treating the entire simple-threshold region as safe exploration.
+"""
+from pathlib import Path
+import argparse
+
+
+def replace_once(text: str, old: str, new: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"expected exactly one match, found {count}: {old!r}")
+    return text.replace(old, new, 1)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True)
+    ap.add_argument("--output", required=True)
+    args = ap.parse_args()
+    text = Path(args.input).read_text()
+
+    text = replace_once(
+        text,
+        'constexpr std::size_t kFreshAge = 4;\n',
+        'constexpr std::size_t kFreshAge = 4;\n'
+        'constexpr double kOneSidedWarmupProbeRatio = 0.25;\n'
+    )
+    text = replace_once(
+        text,
+        '        } else if (!have_incremental) {\n'
+        '          choose_full = update_fraction >= simple_update_fraction;\n'
+        '          trace.reason = choose_full ? "large_warmup_full" : "large_warmup_incremental";\n',
+        '        } else if (!have_incremental && have_full) {\n'
+        '          // One-sided model: full cost is known but incremental cost is not.\n'
+        '          // Preserve exploration only for a deliberately small probe region;\n'
+        '          // otherwise prefer the measured baseline until an incremental sample exists.\n'
+        '          const double probe_fraction =\n'
+        '              simple_update_fraction * kOneSidedWarmupProbeRatio;\n'
+        '          choose_full = update_fraction >= probe_fraction;\n'
+        '          trace.reason = choose_full ? "large_one_sided_full" : "large_one_sided_probe_incremental";\n'
+        '        } else if (!have_incremental) {\n'
+        '          choose_full = update_fraction >= simple_update_fraction;\n'
+        '          trace.reason = choose_full ? "large_warmup_full" : "large_warmup_incremental";\n'
+    )
+    text = replace_once(
+        text,
+        '\"schema_version\\\":6,\\\"selector\\\":\\\"scale-conditioned-selector-owned-v3\\\"',
+        '\"schema_version\\\":7,\\\"selector\\\":\\\"one-sided-warmup-v4\\\"'
+    )
+    text = replace_once(
+        text,
+        '            << ",\\\"fresh_age\\\":" << kFreshAge << "}"\n',
+        '            << ",\\\"fresh_age\\\":" << kFreshAge\n'
+        '            << ",\\\"one_sided_warmup_probe_ratio\\\":" << kOneSidedWarmupProbeRatio << "}"\n'
+    )
+    Path(args.output).write_text(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/issue61_one_sided_warmup.py
+++ b/tools/issue61_one_sided_warmup.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Apply the Issue #61 one-sided warm-up selector candidate.
+"""Apply the Issue #61 bounded one-sided warm-up selector candidate.
 
 When a large-graph selector has a measured full-recompute cost but no incremental
-observation yet, prefer that measured baseline instead of forcing an unmeasured
-incremental warm-up. This directly addresses the one-sided-model failure reported
-in #61. Incremental exploration remains available in regimes where the selector
-has not yet obtained a full-cost observation.
+observation yet, retain the measured full baseline for one one-sided warm-up
+batch, then permit an incremental probe. This fixes the reported second-batch
+cold-start decision without allowing the selector to remain permanently stuck
+on full recomputation.
 """
 from pathlib import Path
 import argparse
@@ -27,22 +27,29 @@ def main() -> None:
 
     text = replace_once(
         text,
+        '  bool first_batch = true;\n',
+        '  bool first_batch = true;\n'
+        '  bool one_sided_full_warmup_used = false;\n'
+    )
+    text = replace_once(
+        text,
         '        } else if (!have_incremental) {\n'
         '          choose_full = update_fraction >= simple_update_fraction;\n'
         '          trace.reason = choose_full ? "large_warmup_full" : "large_warmup_incremental";\n',
-        '        } else if (!have_incremental && have_full) {\n'
-        '          // One-sided model: full cost is measured while incremental cost is unknown.\n'
-        '          // Do not force an unmeasured incremental warm-up; retain the measured baseline.\n'
+        '        } else if (!have_incremental && have_full && !one_sided_full_warmup_used) {\n'
+        '          // Full cost is measured while incremental cost is unknown. Keep the measured\n'
+        '          // baseline for one warm-up decision, then allow an incremental calibration probe.\n'
         '          choose_full = true;\n'
+        '          one_sided_full_warmup_used = true;\n'
         '          trace.reason = "large_one_sided_full";\n'
         '        } else if (!have_incremental) {\n'
         '          choose_full = update_fraction >= simple_update_fraction;\n'
-        '          trace.reason = choose_full ? "large_warmup_full" : "large_warmup_incremental";\n'
+        '          trace.reason = choose_full ? "large_warmup_full" : "large_one_sided_probe_incremental";\n'
     )
     text = replace_once(
         text,
         '\"schema_version\\\":6,\\\"selector\\\":\\\"scale-conditioned-selector-owned-v3\\\"',
-        '\"schema_version\\\":7,\\\"selector\\\":\\\"one-sided-warmup-v4\\\"'
+        '\"schema_version\\\":7,\\\"selector\\\":\\\"bounded-one-sided-warmup-v5\\\"'
     )
     Path(args.output).write_text(text)
 

--- a/tools/issue61_one_sided_warmup.py
+++ b/tools/issue61_one_sided_warmup.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Apply the Issue #61 one-sided warm-up selector candidate.
 
-The candidate keeps exploration for very small update batches, but when a large-graph
-selector has a measured full-recompute cost and no incremental observation yet, it
-uses a stricter bounded-probe threshold (25% of the configured simple threshold)
-instead of treating the entire simple-threshold region as safe exploration.
+When a large-graph selector has a measured full-recompute cost but no incremental
+observation yet, prefer that measured baseline instead of forcing an unmeasured
+incremental warm-up. This directly addresses the one-sided-model failure reported
+in #61. Incremental exploration remains available in regimes where the selector
+has not yet obtained a full-cost observation.
 """
 from pathlib import Path
 import argparse
@@ -26,23 +27,14 @@ def main() -> None:
 
     text = replace_once(
         text,
-        'constexpr std::size_t kFreshAge = 4;\n',
-        'constexpr std::size_t kFreshAge = 4;\n'
-        'constexpr double kOneSidedWarmupProbeRatio = 0.25;\n'
-    )
-    text = replace_once(
-        text,
         '        } else if (!have_incremental) {\n'
         '          choose_full = update_fraction >= simple_update_fraction;\n'
         '          trace.reason = choose_full ? "large_warmup_full" : "large_warmup_incremental";\n',
         '        } else if (!have_incremental && have_full) {\n'
-        '          // One-sided model: full cost is known but incremental cost is not.\n'
-        '          // Preserve exploration only for a deliberately small probe region;\n'
-        '          // otherwise prefer the measured baseline until an incremental sample exists.\n'
-        '          const double probe_fraction =\n'
-        '              simple_update_fraction * kOneSidedWarmupProbeRatio;\n'
-        '          choose_full = update_fraction >= probe_fraction;\n'
-        '          trace.reason = choose_full ? "large_one_sided_full" : "large_one_sided_probe_incremental";\n'
+        '          // One-sided model: full cost is measured while incremental cost is unknown.\n'
+        '          // Do not force an unmeasured incremental warm-up; retain the measured baseline.\n'
+        '          choose_full = true;\n'
+        '          trace.reason = "large_one_sided_full";\n'
         '        } else if (!have_incremental) {\n'
         '          choose_full = update_fraction >= simple_update_fraction;\n'
         '          trace.reason = choose_full ? "large_warmup_full" : "large_warmup_incremental";\n'
@@ -51,12 +43,6 @@ def main() -> None:
         text,
         '\"schema_version\\\":6,\\\"selector\\\":\\\"scale-conditioned-selector-owned-v3\\\"',
         '\"schema_version\\\":7,\\\"selector\\\":\\\"one-sided-warmup-v4\\\"'
-    )
-    text = replace_once(
-        text,
-        '            << ",\\\"fresh_age\\\":" << kFreshAge << "}"\n',
-        '            << ",\\\"fresh_age\\\":" << kFreshAge\n'
-        '            << ",\\\"one_sided_warmup_probe_ratio\\\":" << kOneSidedWarmupProbeRatio << "}"\n'
     )
     Path(args.output).write_text(text)
 

--- a/tools/refine_adaptive_selector.py
+++ b/tools/refine_adaptive_selector.py
@@ -42,7 +42,7 @@ def main() -> None:
 
     text = replace_once(
         text,
-        "        } else if (shallow_cold_start) {\n          choose_full = true;\n          trace.reason = \"large_shallow_cold_start\";\n        } else if (!have_incremental) {",
+        "        } else if (shallow_cold_start) {\n          choose_full = true;\n          trace.reason = \"large_shallow_cold_start\";\n        } else if (!have_incremental && have_full && !one_sided_full_warmup_used) {",
         "        } else if (shallow_cold_start) {\n"
         "          choose_full = true;\n"
         "          trace.reason = \"large_shallow_cold_start\";\n"
@@ -50,14 +50,14 @@ def main() -> None:
         "                   update_fraction >= kLargeGraphUpdateGuard) {\n"
         "          choose_full = true;\n"
         "          trace.reason = \"large_root_locality_update_guard\";\n"
-        "        } else if (!have_incremental) {"
+        "        } else if (!have_incremental && have_full && !one_sided_full_warmup_used) {"
     )
 
     text = replace_once(
         text,
-        "          trace.reason = choose_full ? \"large_warmup_full\" : \"large_warmup_incremental\";",
+        "          trace.reason = choose_full ? \"large_warmup_full\" : \"large_one_sided_probe_incremental\";",
         "          trace.reason = choose_full ? \"large_warmup_full\" :\n"
-        "              (guarded_root ? \"large_root_locality_guarded_incremental\" : \"large_warmup_incremental\");"
+        "              (guarded_root ? \"large_root_locality_guarded_incremental\" : \"large_one_sided_probe_incremental\");"
     )
 
     text = replace_once(
@@ -74,7 +74,7 @@ def main() -> None:
 
     text = replace_once(
         text,
-        "\"schema_version\\\":6,\\\"selector\\\":\\\"scale-conditioned-selector-owned-v3\\\"",
+        "\"schema_version\\\":7,\\\"selector\\\":\\\"bounded-one-sided-warmup-v5\\\"",
         "\"schema_version\\\":8,\\\"selector\\\":\\\"root-locality-affected-work-v5\\\""
     )
 


### PR DESCRIPTION
Addresses the adaptive-selector limitation reported in #61 by @Abhinaydesu75.

This branch implements and validates a bounded one-sided warm-up policy for large-scale adaptive BFS. The final behavior is:

- when the selector has a measured full-recompute cost but no incremental observation yet, it keeps the measured full baseline for one warm-up decision;
- after that bounded full warm-up, it permits an incremental calibration probe so the selector cannot remain permanently stuck on full recomputation;
- once both full and incremental observations exist, the existing uncertainty-aware comparison continues to govern the decision.

Validation includes:

- the exact `web-Google` reproduction from #61 (`root=771121`, `initial_rate=0.99`, `batch=32768`, `simple_threshold=0.05`);
- exactness as a hard invariant;
- a 3-dataset × 3-root × 3-regime campaign across `ca-GrQc`, `soc-Epinions1`, and `web-Google`, with repeated runs;
- machine-readable before/after artifacts and an evidence gate that rejects a candidate that does not improve the #61 target case or regresses the broader campaign beyond the allowed tolerance.

The implementation updates the benchmark selector metadata to schema version 7 / `bounded-one-sided-warmup-v5` and adds explicit trace reasons for the one-sided full warm-up and later incremental probe.

The final branch also updates the adaptive-selector refinement tooling so it remains compatible with the Issue #61 selector state. Current CI, benchmark contracts, security checks, multidataset crossover, same-machine BFS campaign, and adaptive selector refinement checks are green on the PR head.

Credit: thanks to @Abhinaydesu75 for the reproducible report, repeated timings, exactness check, and source-level diagnosis in #61.

Earlier candidate iterations were intentionally rejected by the validation gates when they did not satisfy the target-case evidence requirement; the gates were not weakened to obtain a green result.