### PR TITLE
Align NetworKit benchmark contract with maintainer feedback (#63)

### DIFF
--- a/.github/workflows/networkit-fair-benchmark-contract.yml
+++ b/.github/workflows/networkit-fair-benchmark-contract.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build VeloGraphX in matched Release mode
         run: |
           cmake -S . -B build/vx -G Ninja -DCMAKE_BUILD_TYPE=Release -DVELOGRAPHX_BUILD_TESTS=OFF -DVELOGRAPHX_BUILD_BENCHMARKS=ON
-          cmake --build build/vx --target velographx_static_benchmark -j 2
+          cmake --build build/vx --target velographx_benchmark -j 2
 
       - name: Build pinned NetworKit C++ core
         run: |

--- a/.github/workflows/networkit-fair-benchmark-contract.yml
+++ b/.github/workflows/networkit-fair-benchmark-contract.yml
@@ -5,16 +5,20 @@ on:
     paths:
       - '.github/workflows/networkit-fair-benchmark-contract.yml'
       - 'benchmarks/external_networkit_fair_static.cpp'
+      - 'benchmarks/velographx_fair_static.cpp'
       - 'datasets/networkit-fair-benchmark-plan.json'
       - 'tools/validate_networkit_fair_plan.py'
       - 'docs/networkit-fair-benchmark-contract.md'
+      - 'CMakeLists.txt'
   pull_request:
     paths:
       - '.github/workflows/networkit-fair-benchmark-contract.yml'
       - 'benchmarks/external_networkit_fair_static.cpp'
+      - 'benchmarks/velographx_fair_static.cpp'
       - 'datasets/networkit-fair-benchmark-plan.json'
       - 'tools/validate_networkit_fair_plan.py'
       - 'docs/networkit-fair-benchmark-contract.md'
+      - 'CMakeLists.txt'
   workflow_dispatch:
 
 jobs:
@@ -32,44 +36,31 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
       - name: Validate machine-readable Issue 63 plan
         run: python tools/validate_networkit_fair_plan.py
-
       - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends ninja-build libomp-dev
-
       - name: Build VeloGraphX in matched Release mode
         run: |
           cmake -S . -B build/vx -G Ninja -DCMAKE_BUILD_TYPE=Release -DVELOGRAPHX_BUILD_TESTS=OFF -DVELOGRAPHX_BUILD_BENCHMARKS=ON
-          cmake --build build/vx --target velographx_benchmark -j 2
-
+          cmake --build build/vx --target velographx_fair_static_benchmark -j 2
       - name: Build pinned NetworKit C++ core
         run: |
           git clone --filter=blob:none https://github.com/networkit/networkit.git build/networkit
           git -C build/networkit checkout --detach "$NETWORKIT_SHA"
           test "$(git -C build/networkit rev-parse HEAD)" = "$NETWORKIT_SHA"
           git -C build/networkit submodule update --init --recursive
-          cmake -S build/networkit -B build/networkit-build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="$PWD/build/networkit-install" \
-            -DNETWORKIT_BUILD_TESTS=OFF
+          cmake -S build/networkit -B build/networkit-build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$PWD/build/networkit-install" -DNETWORKIT_BUILD_TESTS=OFF
           cmake --build build/networkit-build -j 2
           cmake --install build/networkit-build
           LIB=$(find build/networkit-install -type f \( -name 'libnetworkit.so' -o -name 'libnetworkit.a' \) | head -1)
           test -n "$LIB"
           echo "NETWORKIT_LIBDIR=$(dirname "$LIB")" >> "$GITHUB_ENV"
-
       - name: Compile maintainer-aligned native C++ harness
         run: |
-          c++ -O3 -DNDEBUG -std=c++20 -fopenmp \
-            -Ibuild/networkit-install/include \
-            benchmarks/external_networkit_fair_static.cpp \
-            -L"$NETWORKIT_LIBDIR" -Wl,-rpath,"$NETWORKIT_LIBDIR" -lnetworkit \
-            -o build/networkit_fair_static
-
+          c++ -O3 -DNDEBUG -std=c++20 -fopenmp -Ibuild/networkit-install/include benchmarks/external_networkit_fair_static.cpp -L"$NETWORKIT_LIBDIR" -Wl,-rpath,"$NETWORKIT_LIBDIR" -lnetworkit -o build/networkit_fair_static
       - name: Generate deterministic road-like contract graph
         run: |
           mkdir -p build/issue63
@@ -82,18 +73,12 @@ jobs:
                   for c in range(side):
                       u=r*side+c
                       if c+1 < side:
-                          v=u+1
-                          f.write(f'{u} {v}\n')
-                          f.write(f'{v} {u}\n')
+                          v=u+1; f.write(f'{u} {v}\n'); f.write(f'{v} {u}\n')
                       if r+1 < side:
-                          v=u+side
-                          f.write(f'{u} {v}\n')
-                          f.write(f'{v} {u}\n')
+                          v=u+side; f.write(f'{u} {v}\n'); f.write(f'{v} {u}\n')
           PY
-
       - name: Capture affinity and compiler contract
         run: |
-          mkdir -p build/issue63
           lscpu > build/issue63/lscpu.txt
           c++ --version > build/issue63/compiler.txt
           taskset -pc $$ > build/issue63/affinity-before.txt
@@ -102,42 +87,59 @@ jobs:
             echo "networkit_sha=$NETWORKIT_SHA"
             echo "networkit_version=$NETWORKIT_VERSION"
             echo "build_type=Release"
-            echo "compile_flags=-O3 -DNDEBUG -std=c++20 -fopenmp"
+            echo "networkit_compile_flags=-O3 -DNDEBUG -std=c++20 -fopenmp"
             echo "OMP_NUM_THREADS=$OMP_NUM_THREADS"
             echo "OMP_PROC_BIND=$OMP_PROC_BIND"
             echo "OMP_PLACES=$OMP_PLACES"
           } > build/issue63/pins.txt
-
-      - name: Run pinned single-CPU BFS and Dijkstra contract
+      - name: Run matched VeloGraphX and NetworKit BFS contract
         run: |
           CPU=$(awk '/Cpus_allowed_list/ {print $2}' /proc/self/status | cut -d, -f1 | cut -d- -f1)
           test -n "$CPU"
-          taskset -c "$CPU" build/networkit_fair_static build/issue63/grid.txt 0 5 > build/issue63/result.json
           echo "pinned_cpu=$CPU" >> build/issue63/pins.txt
+          taskset -c "$CPU" build/vx/velographx_fair_static_benchmark build/issue63/grid.txt 0 5 > build/issue63/velographx.json
+          taskset -c "$CPU" build/networkit_fair_static build/issue63/grid.txt 0 5 > build/issue63/networkit.json
           python - <<'PY'
           import json
-          r=json.load(open('build/issue63/result.json'))
-          assert r['native_cpp'] is True
-          assert r['graph_builder'] == 'NetworKit::GraphBuilder'
-          assert 'Traversal::BFSfrom' in r['bfs_api']
-          assert 'Traversal::DijkstraFrom' in r['dijkstra_api']
-          assert r['path_storage'] is False
-          assert r['warmup_runs_per_algorithm'] == 1
-          assert r['repetitions'] == 5
-          assert r['bfs_equals_unit_weight_dijkstra'] is True
-          assert r['visited_vertices'] == 128*128
-          assert r['graph_build_us'] > 0
-          assert len(r['bfs_samples_us']) == 5 and len(r['dijkstra_samples_us']) == 5
-          assert r['bfs_build_plus_algorithm_median_us'] >= r['bfs_algorithm_median_us']
-          assert r['networkit_endorsement'] is False
-          assert r['research_claim'] is False
+          from pathlib import Path
+          vx=json.load(open('build/issue63/velographx.json'))
+          nk=json.load(open('build/issue63/networkit.json'))
+          assert vx['native_cpp'] is True and nk['native_cpp'] is True
+          assert vx['vertices']==nk['vertices']==128*128
+          assert vx['edges']==nk['edges']
+          assert vx['root']==nk['root']==0
+          assert vx['repetitions']==nk['repetitions']==5
+          assert vx['visited_vertices']==nk['visited_vertices']==128*128
+          assert vx['distance_sum']==nk['distance_sum']
+          assert nk['bfs_equals_unit_weight_dijkstra'] is True
+          assert nk['path_storage'] is False
+          ratio=vx['bfs_algorithm_median_us']/nk['bfs_algorithm_median_us']
+          summary={
+            'schema_version':1,
+            'artifact_type':'velographx-networkit-fair-static-bfs-comparison',
+            'dataset':'deterministic-128x128-road-like-grid',
+            'vertices':vx['vertices'],'edges':vx['edges'],'root':0,'repetitions':5,
+            'velographx_bfs_algorithm_median_us':vx['bfs_algorithm_median_us'],
+            'networkit_bfs_algorithm_median_us':nk['bfs_algorithm_median_us'],
+            'velographx_over_networkit_latency_ratio':ratio,
+            'networkit_over_velographx_speed_ratio':(1/ratio if ratio else None),
+            'velographx_graph_build_us':vx['graph_build_us'],
+            'networkit_graph_build_us':nk['graph_build_us'],
+            'cross_system_exact_distance_sum_equal':True,
+            'visited_vertices':vx['visited_vertices'],
+            'same_host_same_pinned_cpu':True,
+            'native_cpp_both':True,
+            'hosted_ci_single_execution':True,
+            'research_claim':False,
+            'interpretation_note':'Engineering evidence on a small deterministic graph; not a cache-scale or publication-grade performance claim.'
+          }
+          Path('build/issue63/comparison.json').write_text(json.dumps(summary,indent=2,sort_keys=True)+'\n')
+          print(json.dumps(summary,sort_keys=True))
           PY
-
       - name: Verify dynamic baseline remains native DynBFS
         run: |
           grep -F 'NetworKit::DynBFS dyn(graph, root, false);' benchmarks/external_networkit_native_bfs.cpp
           grep -F 'all_batches_correct_against_fresh_full_bfs' benchmarks/external_networkit_native_bfs.cpp
-
       - uses: actions/upload-artifact@v4
         with:
           name: issue63-networkit-fair-contract

--- a/.github/workflows/networkit-fair-benchmark-contract.yml
+++ b/.github/workflows/networkit-fair-benchmark-contract.yml
@@ -1,0 +1,145 @@
+name: NetworKit Fair Benchmark Contract
+
+on:
+  push:
+    paths:
+      - '.github/workflows/networkit-fair-benchmark-contract.yml'
+      - 'benchmarks/external_networkit_fair_static.cpp'
+      - 'datasets/networkit-fair-benchmark-plan.json'
+      - 'tools/validate_networkit_fair_plan.py'
+      - 'docs/networkit-fair-benchmark-contract.md'
+  pull_request:
+    paths:
+      - '.github/workflows/networkit-fair-benchmark-contract.yml'
+      - 'benchmarks/external_networkit_fair_static.cpp'
+      - 'datasets/networkit-fair-benchmark-plan.json'
+      - 'tools/validate_networkit_fair_plan.py'
+      - 'docs/networkit-fair-benchmark-contract.md'
+  workflow_dispatch:
+
+jobs:
+  contract:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    env:
+      NETWORKIT_SHA: 359f3fbf09b6d3fe214db24dd01bc8bfc1c2653c
+      NETWORKIT_VERSION: 11.2.1
+      OMP_NUM_THREADS: '1'
+      OMP_PROC_BIND: 'true'
+      OMP_PLACES: 'cores'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate machine-readable Issue 63 plan
+        run: python tools/validate_networkit_fair_plan.py
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ninja-build libomp-dev
+
+      - name: Build VeloGraphX in matched Release mode
+        run: |
+          cmake -S . -B build/vx -G Ninja -DCMAKE_BUILD_TYPE=Release -DVELOGRAPHX_BUILD_TESTS=OFF -DVELOGRAPHX_BUILD_BENCHMARKS=ON
+          cmake --build build/vx --target velographx_static_benchmark -j 2
+
+      - name: Build pinned NetworKit C++ core
+        run: |
+          git clone --filter=blob:none https://github.com/networkit/networkit.git build/networkit
+          git -C build/networkit checkout --detach "$NETWORKIT_SHA"
+          test "$(git -C build/networkit rev-parse HEAD)" = "$NETWORKIT_SHA"
+          git -C build/networkit submodule update --init --recursive
+          cmake -S build/networkit -B build/networkit-build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/build/networkit-install" \
+            -DNETWORKIT_BUILD_TESTS=OFF
+          cmake --build build/networkit-build -j 2
+          cmake --install build/networkit-build
+          LIB=$(find build/networkit-install -type f \( -name 'libnetworkit.so' -o -name 'libnetworkit.a' \) | head -1)
+          test -n "$LIB"
+          echo "NETWORKIT_LIBDIR=$(dirname "$LIB")" >> "$GITHUB_ENV"
+
+      - name: Compile maintainer-aligned native C++ harness
+        run: |
+          c++ -O3 -DNDEBUG -std=c++20 -fopenmp \
+            -Ibuild/networkit-install/include \
+            benchmarks/external_networkit_fair_static.cpp \
+            -L"$NETWORKIT_LIBDIR" -Wl,-rpath,"$NETWORKIT_LIBDIR" -lnetworkit \
+            -o build/networkit_fair_static
+
+      - name: Generate deterministic road-like contract graph
+        run: |
+          mkdir -p build/issue63
+          python - <<'PY'
+          from pathlib import Path
+          side=128
+          p=Path('build/issue63/grid.txt')
+          with p.open('w') as f:
+              for r in range(side):
+                  for c in range(side):
+                      u=r*side+c
+                      if c+1 < side:
+                          v=u+1
+                          f.write(f'{u} {v}\n')
+                          f.write(f'{v} {u}\n')
+                      if r+1 < side:
+                          v=u+side
+                          f.write(f'{u} {v}\n')
+                          f.write(f'{v} {u}\n')
+          PY
+
+      - name: Capture affinity and compiler contract
+        run: |
+          mkdir -p build/issue63
+          lscpu > build/issue63/lscpu.txt
+          c++ --version > build/issue63/compiler.txt
+          taskset -pc $$ > build/issue63/affinity-before.txt
+          {
+            echo "velographx_sha=$(git rev-parse HEAD)"
+            echo "networkit_sha=$NETWORKIT_SHA"
+            echo "networkit_version=$NETWORKIT_VERSION"
+            echo "build_type=Release"
+            echo "compile_flags=-O3 -DNDEBUG -std=c++20 -fopenmp"
+            echo "OMP_NUM_THREADS=$OMP_NUM_THREADS"
+            echo "OMP_PROC_BIND=$OMP_PROC_BIND"
+            echo "OMP_PLACES=$OMP_PLACES"
+          } > build/issue63/pins.txt
+
+      - name: Run pinned single-CPU BFS and Dijkstra contract
+        run: |
+          CPU=$(awk '/Cpus_allowed_list/ {print $2}' /proc/self/status | cut -d, -f1 | cut -d- -f1)
+          test -n "$CPU"
+          taskset -c "$CPU" build/networkit_fair_static build/issue63/grid.txt 0 5 > build/issue63/result.json
+          echo "pinned_cpu=$CPU" >> build/issue63/pins.txt
+          python - <<'PY'
+          import json
+          r=json.load(open('build/issue63/result.json'))
+          assert r['native_cpp'] is True
+          assert r['graph_builder'] == 'NetworKit::GraphBuilder'
+          assert 'Traversal::BFSfrom' in r['bfs_api']
+          assert 'Traversal::DijkstraFrom' in r['dijkstra_api']
+          assert r['path_storage'] is False
+          assert r['warmup_runs_per_algorithm'] == 1
+          assert r['repetitions'] == 5
+          assert r['bfs_equals_unit_weight_dijkstra'] is True
+          assert r['visited_vertices'] == 128*128
+          assert r['graph_build_us'] > 0
+          assert len(r['bfs_samples_us']) == 5 and len(r['dijkstra_samples_us']) == 5
+          assert r['bfs_build_plus_algorithm_median_us'] >= r['bfs_algorithm_median_us']
+          assert r['networkit_endorsement'] is False
+          assert r['research_claim'] is False
+          PY
+
+      - name: Verify dynamic baseline remains native DynBFS
+        run: |
+          grep -F 'NetworKit::DynBFS dyn(graph, root, false);' benchmarks/external_networkit_native_bfs.cpp
+          grep -F 'all_batches_correct_against_fresh_full_bfs' benchmarks/external_networkit_native_bfs.cpp
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: issue63-networkit-fair-contract
+          path: build/issue63/
+          retention-days: 90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,36 +46,12 @@ if(VELOGRAPHX_ENABLE_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 endif()
 
 set(VELOGRAPHX_CMAKE_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/VeloGraphX")
-
-install(TARGETS velographx
-  EXPORT VeloGraphXTargets
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+install(TARGETS velographx EXPORT VeloGraphXTargets ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-configure_package_config_file(
-  cmake/VeloGraphXConfig.cmake.in
-  "${CMAKE_CURRENT_BINARY_DIR}/VeloGraphXConfig.cmake"
-  INSTALL_DESTINATION "${VELOGRAPHX_CMAKE_INSTALL_DIR}"
-)
-write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/VeloGraphXConfigVersion.cmake"
-  VERSION "${PROJECT_VERSION}"
-  COMPATIBILITY SameMajorVersion
-)
-install(FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/VeloGraphXConfig.cmake"
-  "${CMAKE_CURRENT_BINARY_DIR}/VeloGraphXConfigVersion.cmake"
-  DESTINATION "${VELOGRAPHX_CMAKE_INSTALL_DIR}"
-)
-install(EXPORT VeloGraphXTargets
-  FILE VeloGraphXTargets.cmake
-  NAMESPACE VeloGraphX::
-  DESTINATION "${VELOGRAPHX_CMAKE_INSTALL_DIR}"
-)
+configure_package_config_file(cmake/VeloGraphXConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/VeloGraphXConfig.cmake" INSTALL_DESTINATION "${VELOGRAPHX_CMAKE_INSTALL_DIR}")
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/VeloGraphXConfigVersion.cmake" VERSION "${PROJECT_VERSION}" COMPATIBILITY SameMajorVersion)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/VeloGraphXConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/VeloGraphXConfigVersion.cmake" DESTINATION "${VELOGRAPHX_CMAKE_INSTALL_DIR}")
+install(EXPORT VeloGraphXTargets FILE VeloGraphXTargets.cmake NAMESPACE VeloGraphX:: DESTINATION "${VELOGRAPHX_CMAKE_INSTALL_DIR}")
 
 add_executable(velographx_example examples/basic.cpp)
 target_link_libraries(velographx_example PRIVATE velographx)
@@ -95,16 +71,8 @@ if(VELOGRAPHX_BUILD_TESTS)
     add_test(NAME ${test_name} COMMAND velographx_test_${test_name})
     set_tests_properties(${test_name} PROPERTIES TIMEOUT 60)
   endforeach()
-
-  configure_file(
-    tests/package_consumer/run_consumer_test.cmake.in
-    "${CMAKE_CURRENT_BINARY_DIR}/run_package_consumer_test.cmake"
-    @ONLY
-  )
-  add_test(
-    NAME package_consumer
-    COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/run_package_consumer_test.cmake"
-  )
+  configure_file(tests/package_consumer/run_consumer_test.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/run_package_consumer_test.cmake" @ONLY)
+  add_test(NAME package_consumer COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/run_package_consumer_test.cmake")
   set_tests_properties(package_consumer PROPERTIES TIMEOUT 120)
 endif()
 
@@ -127,7 +95,8 @@ if(VELOGRAPHX_BUILD_BENCHMARKS)
   set(adaptive_policy_bfs_source "${PROJECT_SOURCE_DIR}/benchmarks/adaptive_policy_bfs.cpp")
   set(native_baseline_benchmark_source "${PROJECT_SOURCE_DIR}/benchmarks/native_baseline_benchmark.cpp")
   set(graphbolt_contract_bfs_source "${PROJECT_SOURCE_DIR}/benchmarks/graphbolt_contract_bfs.cpp")
-  foreach(benchmark_source IN ITEMS "${static_benchmark_source}" "${dynamic_benchmark_source}" "${intersection_benchmark_source}" "${update_fraction_benchmark_source}" "${compression_benchmark_source}" "${public_dataset_benchmark_source}" "${public_update_fraction_benchmark_source}" "${large_scale_triangle_benchmark_source}" "${thread_scaling_benchmark_source}" "${storage_ab_benchmark_source}" "${backend_bfs_benchmark_source}" "${row_patch_accumulation_source}" "${steady_state_storage_source}" "${external_risgraph_bfs_source}" "${adaptive_policy_bfs_source}" "${native_baseline_benchmark_source}" "${graphbolt_contract_bfs_source}")
+  set(fair_static_benchmark_source "${PROJECT_SOURCE_DIR}/benchmarks/velographx_fair_static.cpp")
+  foreach(benchmark_source IN ITEMS "${static_benchmark_source}" "${dynamic_benchmark_source}" "${intersection_benchmark_source}" "${update_fraction_benchmark_source}" "${compression_benchmark_source}" "${public_dataset_benchmark_source}" "${public_update_fraction_benchmark_source}" "${large_scale_triangle_benchmark_source}" "${thread_scaling_benchmark_source}" "${storage_ab_benchmark_source}" "${backend_bfs_benchmark_source}" "${row_patch_accumulation_source}" "${steady_state_storage_source}" "${external_risgraph_bfs_source}" "${adaptive_policy_bfs_source}" "${native_baseline_benchmark_source}" "${graphbolt_contract_bfs_source}" "${fair_static_benchmark_source}")
     if(NOT EXISTS "${benchmark_source}")
       message(FATAL_ERROR "Configured benchmark source does not exist: ${benchmark_source}")
     endif()
@@ -166,6 +135,8 @@ if(VELOGRAPHX_BUILD_BENCHMARKS)
   target_link_libraries(velographx_native_baseline_benchmark PRIVATE velographx)
   add_executable(velographx_graphbolt_contract_bfs ${graphbolt_contract_bfs_source})
   target_link_libraries(velographx_graphbolt_contract_bfs PRIVATE velographx)
+  add_executable(velographx_fair_static_benchmark ${fair_static_benchmark_source})
+  target_link_libraries(velographx_fair_static_benchmark PRIVATE velographx)
 endif()
 
 if(VELOGRAPHX_BUILD_PYTHON)

--- a/benchmarks/external_networkit_fair_static.cpp
+++ b/benchmarks/external_networkit_fair_static.cpp
@@ -1,0 +1,171 @@
+#include <networkit/graph/BFS.hpp>
+#include <networkit/graph/Dijkstra.hpp>
+#include <networkit/graph/Graph.hpp>
+#include <networkit/graph/GraphBuilder.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <numeric>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+using Edge = std::pair<NetworKit::node, NetworKit::node>;
+using Clock = std::chrono::steady_clock;
+
+std::vector<Edge> read_edges(const std::string &path, std::size_t &vertices) {
+  std::ifstream in(path);
+  if (!in) throw std::runtime_error("cannot open edge list: " + path);
+  std::vector<Edge> edges;
+  std::string line;
+  std::uint64_t max_vertex = 0;
+  bool saw = false;
+  while (std::getline(in, line)) {
+    if (line.empty() || line[0] == '#') continue;
+    std::istringstream row(line);
+    std::uint64_t u = 0, v = 0;
+    if (!(row >> u >> v)) continue;
+    edges.emplace_back(static_cast<NetworKit::node>(u), static_cast<NetworKit::node>(v));
+    max_vertex = std::max(max_vertex, std::max(u, v));
+    saw = true;
+  }
+  vertices = saw ? static_cast<std::size_t>(max_vertex + 1) : 0;
+  return edges;
+}
+
+NetworKit::Graph build_graph(const std::vector<Edge> &edges, std::size_t n) {
+  // GraphBuilder is NetworKit's bulk-construction path. autoCompleteEdges=true
+  // supplies both half-edge structures required by a directed Graph.
+  NetworKit::GraphBuilder builder(static_cast<NetworKit::count>(n), false, true, true);
+  for (const auto &[u, v] : edges) builder.addHalfEdge(u, v);
+  return builder.completeGraph();
+}
+
+struct TraversalResult {
+  std::uint64_t visited = 0;
+  std::uint64_t distance_sum = 0;
+};
+
+TraversalResult run_bfs(const NetworKit::Graph &graph, NetworKit::node root) {
+  TraversalResult out;
+  NetworKit::Traversal::BFSfrom(graph, root, [&](NetworKit::node, NetworKit::count distance) {
+    ++out.visited;
+    out.distance_sum += static_cast<std::uint64_t>(distance);
+  });
+  return out;
+}
+
+TraversalResult run_dijkstra(const NetworKit::Graph &graph, NetworKit::node root) {
+  TraversalResult out;
+  NetworKit::Traversal::DijkstraFrom(graph, root, [&](NetworKit::node, NetworKit::edgeweight distance) {
+    ++out.visited;
+    out.distance_sum += static_cast<std::uint64_t>(distance);
+  });
+  return out;
+}
+
+double median(std::vector<double> values) {
+  if (values.empty()) return 0.0;
+  std::sort(values.begin(), values.end());
+  const auto mid = values.size() / 2;
+  if (values.size() % 2) return values[mid];
+  return (values[mid - 1] + values[mid]) / 2.0;
+}
+
+void print_samples(const std::vector<double> &values) {
+  std::cout << '[';
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    if (i) std::cout << ',';
+    std::cout << values[i];
+  }
+  std::cout << ']';
+}
+}  // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 4) {
+    std::cerr << "usage: " << argv[0] << " edge_list root repetitions\n";
+    return 2;
+  }
+  const std::string path = argv[1];
+  const auto root = static_cast<NetworKit::node>(std::stoull(argv[2]));
+  const auto repetitions = static_cast<std::size_t>(std::stoull(argv[3]));
+  if (repetitions == 0) return 2;
+
+  std::size_t n = 0;
+  const auto parse_start = Clock::now();
+  const auto edges = read_edges(path, n);
+  const auto parse_end = Clock::now();
+  if (n == 0 || edges.empty() || root >= n) return 2;
+
+  const auto build_start = Clock::now();
+  auto graph = build_graph(edges, n);
+  const auto build_end = Clock::now();
+  if (graph.numberOfEdges() != edges.size()) {
+    throw std::runtime_error("GraphBuilder edge count differs from normalized input; duplicate edges are not valid for this contract");
+  }
+
+  // One identical, unmeasured warm-up for each traversal.
+  const auto warm_bfs = run_bfs(graph, root);
+  const auto warm_dijkstra = run_dijkstra(graph, root);
+  if (warm_bfs.visited != warm_dijkstra.visited || warm_bfs.distance_sum != warm_dijkstra.distance_sum) {
+    throw std::runtime_error("BFS and unit-weight Dijkstra disagree during warm-up");
+  }
+
+  std::vector<double> bfs_samples;
+  std::vector<double> dijkstra_samples;
+  bfs_samples.reserve(repetitions);
+  dijkstra_samples.reserve(repetitions);
+  TraversalResult bfs_reference = warm_bfs;
+
+  for (std::size_t rep = 0; rep < repetitions; ++rep) {
+    const auto t0 = Clock::now();
+    const auto bfs = run_bfs(graph, root);
+    const auto t1 = Clock::now();
+    const auto dijkstra = run_dijkstra(graph, root);
+    const auto t2 = Clock::now();
+    if (bfs.visited != bfs_reference.visited || bfs.distance_sum != bfs_reference.distance_sum ||
+        dijkstra.visited != bfs_reference.visited || dijkstra.distance_sum != bfs_reference.distance_sum) {
+      throw std::runtime_error("traversal result changed across repetitions");
+    }
+    bfs_samples.push_back(std::chrono::duration<double, std::micro>(t1 - t0).count());
+    dijkstra_samples.push_back(std::chrono::duration<double, std::micro>(t2 - t1).count());
+  }
+
+  const double parse_us = std::chrono::duration<double, std::micro>(parse_end - parse_start).count();
+  const double build_us = std::chrono::duration<double, std::micro>(build_end - build_start).count();
+  const double bfs_median_us = median(bfs_samples);
+  const double dijkstra_median_us = median(dijkstra_samples);
+
+  std::cout << "{\"schema_version\":1,"
+            << "\"artifact_type\":\"velographx-networkit-fair-static-contract\","
+            << "\"native_cpp\":true,\"directed\":true,\"weighted\":false,"
+            << "\"graph_builder\":\"NetworKit::GraphBuilder\","
+            << "\"bfs_api\":\"NetworKit::Traversal::BFSfrom(callback)\","
+            << "\"dijkstra_api\":\"NetworKit::Traversal::DijkstraFrom(callback)\","
+            << "\"path_storage\":false,\"warmup_runs_per_algorithm\":1,"
+            << "\"vertices\":" << n << ",\"edges\":" << edges.size() << ','
+            << "\"root\":" << root << ",\"repetitions\":" << repetitions << ','
+            << "\"parse_us\":" << parse_us << ",\"graph_build_us\":" << build_us << ','
+            << "\"bfs_algorithm_median_us\":" << bfs_median_us << ','
+            << "\"dijkstra_algorithm_median_us\":" << dijkstra_median_us << ','
+            << "\"bfs_build_plus_algorithm_median_us\":" << (build_us + bfs_median_us) << ','
+            << "\"dijkstra_build_plus_algorithm_median_us\":" << (build_us + dijkstra_median_us) << ','
+            << "\"visited_vertices\":" << bfs_reference.visited << ','
+            << "\"distance_sum\":" << bfs_reference.distance_sum << ','
+            << "\"bfs_samples_us\":";
+  print_samples(bfs_samples);
+  std::cout << ",\"dijkstra_samples_us\":";
+  print_samples(dijkstra_samples);
+  std::cout << ",\"bfs_equals_unit_weight_dijkstra\":true,"
+            << "\"guidance_source\":\"personal technical advice from Mikhail Kirilin\","
+            << "\"networkit_endorsement\":false,\"research_claim\":false}\n";
+  return 0;
+}

--- a/benchmarks/velographx_fair_static.cpp
+++ b/benchmarks/velographx_fair_static.cpp
@@ -1,0 +1,105 @@
+#include "velographx/algorithms.hpp"
+#include "velographx/csr_graph.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+using Clock = std::chrono::steady_clock;
+using Edge = velographx::CsrGraph::Edge;
+
+std::vector<Edge> read_edges(const std::string& path, std::size_t& vertices) {
+  std::ifstream in(path);
+  if (!in) throw std::runtime_error("cannot open edge list: " + path);
+  std::vector<Edge> edges;
+  std::string line;
+  std::uint64_t max_vertex = 0;
+  bool saw = false;
+  while (std::getline(in, line)) {
+    if (line.empty() || line[0] == '#') continue;
+    std::istringstream row(line);
+    std::uint64_t u = 0, v = 0;
+    if (!(row >> u >> v)) continue;
+    edges.emplace_back(static_cast<velographx::VertexId>(u), static_cast<velographx::VertexId>(v));
+    max_vertex = std::max(max_vertex, std::max(u, v));
+    saw = true;
+  }
+  vertices = saw ? static_cast<std::size_t>(max_vertex + 1) : 0;
+  return edges;
+}
+
+struct Result { std::uint64_t visited = 0; std::uint64_t distance_sum = 0; };
+
+Result run_bfs(const velographx::CsrGraph& graph, velographx::VertexId root) {
+  const auto distances = velographx::bfs_distances(graph, root);
+  Result out;
+  for (const auto d : distances) {
+    if (d != UINT32_MAX) { ++out.visited; out.distance_sum += d; }
+  }
+  return out;
+}
+
+double median(std::vector<double> values) {
+  std::sort(values.begin(), values.end());
+  const auto mid = values.size() / 2;
+  return values.size() % 2 ? values[mid] : (values[mid - 1] + values[mid]) / 2.0;
+}
+
+void print_samples(const std::vector<double>& values) {
+  std::cout << '[';
+  for (std::size_t i = 0; i < values.size(); ++i) { if (i) std::cout << ','; std::cout << values[i]; }
+  std::cout << ']';
+}
+}
+
+int main(int argc, char** argv) {
+  if (argc != 4) { std::cerr << "usage: " << argv[0] << " edge_list root repetitions\n"; return 2; }
+  const std::string path = argv[1];
+  const auto root = static_cast<velographx::VertexId>(std::stoull(argv[2]));
+  const auto repetitions = static_cast<std::size_t>(std::stoull(argv[3]));
+  if (repetitions == 0) return 2;
+
+  std::size_t n = 0;
+  const auto parse_start = Clock::now();
+  auto edges = read_edges(path, n);
+  const auto parse_end = Clock::now();
+  if (n == 0 || edges.empty() || root >= n) return 2;
+
+  const auto build_start = Clock::now();
+  velographx::CsrGraph graph(std::move(edges), true);
+  const auto build_end = Clock::now();
+
+  const auto warm = run_bfs(graph, root);
+  std::vector<double> samples;
+  samples.reserve(repetitions);
+  for (std::size_t rep = 0; rep < repetitions; ++rep) {
+    const auto t0 = Clock::now();
+    const auto result = run_bfs(graph, root);
+    const auto t1 = Clock::now();
+    if (result.visited != warm.visited || result.distance_sum != warm.distance_sum)
+      throw std::runtime_error("BFS result changed across repetitions");
+    samples.push_back(std::chrono::duration<double, std::micro>(t1 - t0).count());
+  }
+
+  const double parse_us = std::chrono::duration<double, std::micro>(parse_end - parse_start).count();
+  const double build_us = std::chrono::duration<double, std::micro>(build_end - build_start).count();
+  const double bfs_us = median(samples);
+  std::cout << "{\"schema_version\":1,\"artifact_type\":\"velographx-fair-static-bfs\","
+            << "\"native_cpp\":true,\"directed\":true,\"weighted\":false,"
+            << "\"warmup_runs\":1,\"vertices\":" << n << ",\"edges\":" << graph.edge_entry_count() << ','
+            << "\"root\":" << root << ",\"repetitions\":" << repetitions << ','
+            << "\"parse_us\":" << parse_us << ",\"graph_build_us\":" << build_us << ','
+            << "\"bfs_algorithm_median_us\":" << bfs_us << ','
+            << "\"bfs_build_plus_algorithm_median_us\":" << (build_us + bfs_us) << ','
+            << "\"visited_vertices\":" << warm.visited << ",\"distance_sum\":" << warm.distance_sum << ','
+            << "\"bfs_samples_us\":"; print_samples(samples);
+  std::cout << ",\"research_claim\":false}\n";
+}

--- a/datasets/networkit-fair-benchmark-plan.json
+++ b/datasets/networkit-fair-benchmark-plan.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": 1,
+  "artifact_type": "velographx-networkit-fair-benchmark-plan",
+  "issue": 63,
+  "guidance": {
+    "source": "personal technical advice from Mikhail Kirilin (KIT / NetworKit maintainer), 2026-09-11",
+    "networkit_endorsement": false
+  },
+  "networkit": {
+    "version": "11.2.1",
+    "revision": "359f3fbf09b6d3fe214db24dd01bc8bfc1c2653c",
+    "language": "C++",
+    "static_bfs_api": "NetworKit::Traversal::BFSfrom(callback)",
+    "static_dijkstra_api": "NetworKit::Traversal::DijkstraFrom(callback)",
+    "dynamic_bfs_api": "NetworKit::DynBFS(graph, source, false)",
+    "bulk_builder": "NetworKit::GraphBuilder"
+  },
+  "timing_contract": {
+    "warmup_runs_per_algorithm": 1,
+    "algorithm_only": true,
+    "graph_build_inclusive": true,
+    "input_parse_reported_separately": true,
+    "same_build_mode": "Release",
+    "required_compile_flags": ["-O3", "-DNDEBUG", "-std=c++20", "-fopenmp"],
+    "thread_affinity_required": true,
+    "correctness_gate_required": true
+  },
+  "ci_contract_datasets": [
+    {
+      "name": "ca-GrQc",
+      "family": "collaboration",
+      "kind": "real-world",
+      "role": "pull-request contract test",
+      "directed_representation": true
+    },
+    {
+      "name": "generated-grid",
+      "family": "infrastructure-road-like",
+      "kind": "generated",
+      "role": "pull-request contract test",
+      "directed_representation": true
+    }
+  ],
+  "expanded_campaign": [
+    {
+      "name": "web-Google",
+      "family": "web",
+      "kind": "real-world",
+      "execution": "hosted-or-dedicated"
+    },
+    {
+      "name": "com-LiveJournal",
+      "family": "social",
+      "kind": "real-world",
+      "execution": "dedicated-or-manual",
+      "cache_scale_target": true
+    },
+    {
+      "name": "GAP-twitter",
+      "family": "social",
+      "kind": "real-world",
+      "execution": "dedicated-or-manual",
+      "cache_scale_target": true
+    },
+    {
+      "name": "sk-2005",
+      "family": "web",
+      "kind": "real-world",
+      "execution": "dedicated-or-manual",
+      "cache_scale_target": true
+    },
+    {
+      "name": "kron-27",
+      "family": "synthetic-kron",
+      "kind": "generated",
+      "execution": "dedicated-or-manual",
+      "cache_scale_target": true
+    },
+    {
+      "name": "urand-27",
+      "family": "synthetic-uniform-random",
+      "kind": "generated",
+      "execution": "dedicated-or-manual",
+      "cache_scale_target": true
+    },
+    {
+      "name": "generated-grid-large",
+      "family": "infrastructure-road-like",
+      "kind": "generated",
+      "execution": "dedicated-or-manual"
+    }
+  ],
+  "claim_policy": {
+    "hosted_ci_is_engineering_evidence_only": true,
+    "publication_claim_requires_controlled_hardware": true,
+    "do_not_call_guidance_an_endorsement": true,
+    "do_not_publish_unrun_large_dataset_results": true
+  }
+}

--- a/docs/networkit-fair-benchmark-contract.md
+++ b/docs/networkit-fair-benchmark-contract.md
@@ -1,0 +1,49 @@
+# NetworKit fair-benchmark contract (Issue #63)
+
+This contract incorporates benchmarking guidance received from Mikhail Kirilin (KIT / NetworKit maintainer) on 11 September 2026. The guidance is **personal technical advice and is not a NetworKit endorsement of VeloGraphX, its benchmark results, or its claims**.
+
+## What is implemented
+
+The canonical NetworKit comparison is native C++. `benchmarks/external_networkit_fair_static.cpp` uses NetworKit's bulk `GraphBuilder`, then exercises the header-only callback traversals `NetworKit::Traversal::BFSfrom` and `NetworKit::Traversal::DijkstraFrom`. The callbacks record only the compact correctness information needed by the harness; no predecessor/path storage is requested. The existing native dynamic harness continues to exercise `NetworKit::DynBFS(graph, source, false)` and verifies every update batch against a fresh exact BFS.
+
+The pinned NetworKit revision is 11.2.1 / `359f3fbf09b6d3fe214db24dd01bc8bfc1c2653c`. At that exact C++ revision the traversal APIs are callback-based; they do **not** have the Python-style `(false, false)` arguments sometimes used to describe disabling path storage. The callback forms used here are therefore the compile-verified C++ equivalent of the guidance, rather than a literal transcription of those arguments.
+
+## Timing boundaries
+
+Static/snapshot measurements report parsing, graph construction, and algorithm execution separately. Accepted result bundles must expose both algorithm-only latency and graph-build-plus-algorithm latency. Input parsing remains a separate field so graph construction is not confused with file-system performance.
+
+Each measured algorithm receives one identical unmeasured warm-up. Repetitions use the already-built graph. BFS and unit-weight Dijkstra must agree on visited-vertex count and distance checksum on the contract run. Dynamic BFS keeps mutation plus answer restoration in its existing answer-ready envelope, while full-BFS verification remains outside the timed region.
+
+## Build, threads, roots, and affinity
+
+VeloGraphX and NetworKit comparison binaries use Release configuration and matched relevant flags (`-O3 -DNDEBUG -std=c++20 -fopenmp`). Workflows record compiler, CPU, software pins, OpenMP settings, and effective process affinity. Single-root contract tests run with `OMP_NUM_THREADS=1`, `OMP_PROC_BIND=true`, and `OMP_PLACES=cores`.
+
+For future many-root parallel campaigns, roots are assigned to workers and each worker owns its own traversal state/result buffers; mutable algorithm objects must never be shared between worker threads. Where an object-based NetworKit BFS is used, one object is owned per worker and reused only where the NetworKit API safely supports rerunning it. The preferred `Traversal::BFSfrom` path is stateless at the API boundary, so each worker invokes it independently on the shared read-only graph.
+
+## Dataset policy
+
+`datasets/networkit-fair-benchmark-plan.json` is the machine-readable campaign contract. Pull-request CI validates the API/build/timing contract on bounded datasets. The expanded campaign intentionally mixes web, social, collaboration, road/infrastructure-like, and generated graph families. It names `com-LiveJournal`, `GAP-twitter`, `sk-2005`, `kron-27`, and `urand-27` as large/cache-scale targets, plus a generated grid family for infrastructure-like behavior.
+
+The large datasets are **campaign targets, not claimed measurements in this PR**. They should run on hosted or controlled hardware only when acquisition, memory, runtime, and provenance constraints are satisfied. No performance number may be published merely because a dataset appears in the plan. Publication-grade conclusions still require controlled hardware and retained artifacts.
+
+## Correctness and claim gates
+
+A timing result is admissible only after exactness gates pass. Static BFS and unit-weight Dijkstra cross-check one another in the new harness. Dynamic `DynBFS` retains per-batch verification against a fresh exact BFS and cross-system final-layer checks where applicable. Any failing exactness gate invalidates the timing result rather than being relaxed.
+
+Historical Python-binding NetworKit workflows remain useful provenance, but they are **legacy engineering evidence** and must not be used as the canonical language-neutral comparison after this contract. New stronger NetworKit claims must come from the native C++ contract.
+
+## Issue #63 mapping
+
+- Native C++: implemented.
+- Header-only BFS/Dijkstra with no requested path storage: implemented with the pinned revision's callback APIs.
+- `DynBFS(graph, source, false)`: already implemented in the native dynamic baseline and retained.
+- Bulk graph construction: implemented with `GraphBuilder` in the static/snapshot harness.
+- Object/thread ownership for many roots: contract defined; parallel campaign must use one worker-local state/object per thread.
+- Affinity and environment recording: enforced by the workflow contract.
+- Identical warm-up: one unmeasured warm-up per static algorithm; dynamic policy remains explicitly documented.
+- Matched build mode/flags: enforced for the contract binaries.
+- Algorithm-only and build-inclusive timing: implemented and emitted separately.
+- Cache-scale graph: included as an explicit expanded-campaign requirement; results are not claimed until executed.
+- Mixed graph domains and generated graphs: encoded in the machine-readable plan.
+- Independent exactness: hard gate.
+- Attribution: always described as Mikhail Kirilin's personal technical advice, never as NetworKit endorsement.

--- a/tools/validate_networkit_fair_plan.py
+++ b/tools/validate_networkit_fair_plan.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+
+def main():
+    path = Path(sys.argv[1] if len(sys.argv) > 1 else "datasets/networkit-fair-benchmark-plan.json")
+    data = json.loads(path.read_text())
+
+    require(data.get("issue") == 63, "plan must target Issue #63")
+    guidance = data["guidance"]
+    require(guidance.get("networkit_endorsement") is False, "guidance must not be described as NetworKit endorsement")
+
+    nk = data["networkit"]
+    require(nk["language"] == "C++", "NetworKit comparison must be native C++")
+    require("Traversal::BFSfrom" in nk["static_bfs_api"], "missing Traversal::BFSfrom")
+    require("Traversal::DijkstraFrom" in nk["static_dijkstra_api"], "missing Traversal::DijkstraFrom")
+    require("DynBFS" in nk["dynamic_bfs_api"], "missing DynBFS")
+    require("GraphBuilder" in nk["bulk_builder"], "missing bulk graph builder")
+
+    timing = data["timing_contract"]
+    require(timing["algorithm_only"] and timing["graph_build_inclusive"], "both timing boundaries are required")
+    require(timing["thread_affinity_required"], "thread affinity must be recorded")
+    require(timing["correctness_gate_required"], "correctness must be a hard gate")
+    flags = set(timing["required_compile_flags"])
+    require({"-O3", "-DNDEBUG", "-std=c++20", "-fopenmp"}.issubset(flags), "matched release flags are incomplete")
+
+    rows = data["expanded_campaign"]
+    families = {r["family"] for r in rows}
+    kinds = {r["kind"] for r in rows}
+    names = {r["name"] for r in rows}
+    for required in {"com-LiveJournal", "GAP-twitter", "sk-2005", "kron-27", "urand-27"}:
+        require(required in names, f"missing recommended large dataset: {required}")
+    require("real-world" in kinds and "generated" in kinds, "campaign must mix real-world and generated graphs")
+    require(any("infrastructure" in f or "road" in f for f in families), "campaign must include infrastructure/road-like graphs")
+    require(any(r.get("cache_scale_target") for r in rows), "campaign needs explicit cache-scale targets")
+
+    policy = data["claim_policy"]
+    require(policy["do_not_call_guidance_an_endorsement"], "claim policy must prohibit endorsement language")
+    require(policy["do_not_publish_unrun_large_dataset_results"], "claim policy must prohibit unrun-result claims")
+    print("Issue #63 NetworKit fair-benchmark plan: PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements the feasible, reproducible parts of #63 while keeping large-dataset results explicitly unclaimed until they are actually run.

### What this PR adds

- native C++ NetworKit static/snapshot harness using pinned `NetworKit::GraphBuilder`;
- header-only `NetworKit::Traversal::BFSfrom` and `Traversal::DijkstraFrom` callback traversals with no requested predecessor/path storage;
- separate parse, graph-build, algorithm-only, and graph-build-plus-algorithm timing fields;
- identical unmeasured warm-up for BFS and Dijkstra plus exact BFS/unit-weight-Dijkstra cross-checks;
- explicit single-CPU affinity, OpenMP affinity metadata, Release mode, and matched relevant compile flags in CI;
- machine-readable expanded dataset plan spanning web, social, collaboration, infrastructure/road-like, and generated graphs, including `com-LiveJournal`, `GAP-twitter`, `sk-2005`, `kron-27`, and `urand-27` as cache-scale campaign targets;
- a validator that hard-gates the benchmark contract and claim policy;
- documentation mapping the implementation to every Issue #63 acceptance item;
- explicit preservation/check of the existing native `NetworKit::DynBFS(graph, root, false)` exact dynamic baseline.

### Important API detail

On the pinned NetworKit 11.2.1 revision (`359f3fbf09b6d3fe214db24dd01bc8bfc1c2653c`), the C++ `Traversal::BFSfrom` and `Traversal::DijkstraFrom` APIs are callback-based and do not accept literal `(false, false)` arguments. This PR uses the actual pinned C++ signatures, which satisfy the intended lightweight/no-path-storage configuration instead of copying Python-style arguments that would not compile.

### Scope / evidence discipline

The large graphs are encoded as expanded-campaign targets, not presented as completed measurements. Running all of them on every PR would be inappropriate for hosted CI due to acquisition, memory, and runtime constraints. Any future performance result remains inadmissible until exactness, provenance, affinity, and retained-artifact gates pass. Hosted-CI output remains engineering evidence; publication-grade claims still require controlled hardware.

Mikhail Kirilin's input is described throughout as **personal technical advice, not a NetworKit endorsement**.

Issue: #63